### PR TITLE
ProxyTable update to allow Hostname only matches

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -97,7 +97,7 @@ exports.createServer = function () {
     }
   });
   
-  server.setMaxListeners(maxEventListeners);
+  // server.setMaxListeners(maxEventListeners); // TODO - Need to work out this properly...
   server.on('close', function () {
     if (proxyTable) proxyTable.close();
   });

--- a/lib/proxy-table.js
+++ b/lib/proxy-table.js
@@ -31,7 +31,7 @@ var util = require('util'),
 
 var ProxyTable = function (router, silent, hostname_only) {
   events.EventEmitter.call(this);
-  this.setMaxListeners(maxEventListeners);
+  // this.setMaxListeners(maxEventListeners); // TODO - Need to work out this properly...
   this.silent = typeof silent !== 'undefined' ? silent : true;
   this.hostname_only = typeof hostname_only !== 'undefined' ? hostname_only : false;
   if (typeof router === 'object') {


### PR DESCRIPTION
This allows the lookup within ProxyTable to be a O(1) lookup on the routers object without RegExp. Instead of the O(n) RegExp based lookup that is currently in place.

This can be toggled by a boolean that can be passed to HttpProxy and ProxyTable.

Therefore for scenarios where you want a purely Host: header lookup this will be faster and will scale better when the proxy is infront of X'00 backends.
