### PR TITLE
Looks like this may fix the issue that I reported

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -45,11 +45,9 @@ exports.version = [0, 5, 0];
 // and sets the `maxSockets` property appropriately.
 //
 function _getAgent (host, port, secure) {
-  var agent = !secure ? http.getAgent(host, port) : https.getAgent({ 
-    host: host, 
-    port: port 
-  });
-      
+  var options = { host: host, port: port };
+  var agent = !secure ? http.getAgent(options) : https.getAgent(options);
+
   agent.maxSockets = maxSockets;
   return agent;
 }


### PR DESCRIPTION
My installation doesn't like the parameters passed as "http, port" to getAgent.  I think instanceof may want these variables to be instantiated with the String constructor according to some JavaScript documentation found online but I'm not sure.

In this patch all I did was create an options object and used it in both the HTTP and HTTPS constructors.  After that the examples work again.
