### PR TITLE
getAgent signature

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -45,8 +45,7 @@ exports.version = [0, 5, 0];
 // and sets the `maxSockets` property appropriately.
 //
 function _getAgent (host, port, secure) {
-  var options = { host: host, port: port };
-  var agent = !secure ? http.getAgent(options) : https.getAgent(options);
+  var agent = !secure ? http.getAgent(host, port) : https.getAgent(host, port);
 
   agent.maxSockets = maxSockets;
   return agent;


### PR DESCRIPTION
Hi,

The `_getAgent()` method is currently passing an options object to `getAgent`, but the signature of that function is `function (host, port)`. This causes some strange behavior for me. This small patch fixes the problem. Tested against Node 0.4.4 and 0.4.7.

Thanks!
