### PR TITLE
Customizable and production error handling

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -358,17 +358,35 @@ HttpProxy.prototype.proxyRequest = function (req, res, options) {
   // Short-circuits `res` in the event of any error when 
   // contacting the proxy target at `host` / `port`.
   //
-  function proxyError(err) {
+   function proxyError(err) {
     errState = true;
+
+    //
+    // Emit an `error` event, allowing the application to use custom
+    // error handling. The error handler should end the response.
+    //
+    if (self.emit('proxyError', err, req, res)) {
+      return;
+    }
+
     res.writeHead(500, { 'Content-Type': 'text/plain' });
 
     if (req.method !== 'HEAD') {
-      res.write('An error has occurred: ' + JSON.stringify(err));
+      //
+      // This NODE_ENV=production behavior is mimics Express and
+      // Connect.
+      //
+      if (process.env.NODE_ENV === 'production') {
+        res.write('Internal Server Error');
+      }
+      else {
+        res.write('An error has occurred: ' + JSON.stringify(err));
+      }
     }
-  
+
     res.end();
   }
-  
+ 
   outgoing = {
     host: options.host,
     port: options.port,


### PR DESCRIPTION
Hi,

Right now, if the proxy request produces and error, a JSON stack trace is written out. 

This patch adds the ability to completely customize this behavior by listening for a `proxyError` event. Otherwise, if `NODE_ENV=production`, the string "Internal Server Error" is written instead of a stack trace. This in-production default behavior mimics Express/Connect. Otherwise, the stack trace is still printed out.

If this implementation isn't suitable, some way to prevent a stack trace in production would be nice.

Best wishes,

-Ben
