### PR TITLE
This adds a flag to ProxyRequest to disable the setting of x-forwarded-[for|port|proto]

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -328,7 +328,7 @@ HttpProxy.prototype.close = function () {
 //     options.host {string} Host of the proxy target.
 //     options.buffer {Object} Result from `httpProxy.buffer(req)`
 //     options.https {Object|boolean} Settings for https.
-//     options.allow_xforwarded_headers {boolean} Don't clobber x-forwarded headers to allow layered proxies.
+//     options.enableXForwarded {boolean} Don't clobber x-forwarded headers to allow layered proxies.
 //
 HttpProxy.prototype.proxyRequest = function (req, res, options) {
   var self = this, errState = false, location, outgoing, protocol, reverseProxy;
@@ -341,7 +341,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, options) {
   options      = options || {};
   options.host = options.host || this.target.host;
   options.port = options.port || this.target.port;
-  options.allow_xforwarded_headers = options.allow_xforwarded_headers || false;
+  options.enableXForwarded = options.enableXForwarded || false;
   
   //
   // Check the proxy table for this instance to see if we need
@@ -381,7 +381,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, options) {
   // * `x-forwarded-proto`: Protocol of the original request
   // * `x-forwarded-port`: Port of the original request. 
   //
-  if (options.allow_xforwarded_headers == true) {
+  if (options.enableXForwarded == true) {
     req.headers['x-forwarded-for']   = req.connection.remoteAddress || req.connection.socket.remoteAddress;
     req.headers['x-forwarded-port']  = req.connection.remotePort || req.connection.socket.remotePort;
     req.headers['x-forwarded-proto'] = res.connection.pair ? 'https' : 'http';


### PR DESCRIPTION
When using multiple layers of proxies one needs the ability not to re-set x-forwarded-[for|port|proto] on every layer; as the first proxy sets these headers on further layers the headers should not be clobbered so the final destination sees the correct address.
