### PR TITLE
The number of maxSockets has to be set after the agent is created. Settin

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -61,9 +61,10 @@ function _getAgent (host, port, secure) {
 
     _agents[id] = new Agent({ 
       host: host, 
-      port: port,
-      maxSockets: maxSockets
+      port: port
     });
+
+    _agents[id].maxSockets = maxSockets;
   }
 
   return _agents[id];


### PR DESCRIPTION
The number of maxSockets has to be set after the agent is created. Setting the property in the constructor does not work.
