### PR TITLE
Fix for websockets to work when options.router is specified without a callback

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -789,6 +789,36 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
   }
 
   //
+  // Check the proxy table for this instance to see if we need
+  // to get the proxy location for the request supplied. We will
+  // always ignore the proxyTable if an explicit `port` and `host`
+  // arguments are supplied to `proxyRequest`.
+  //
+  if (this.proxyTable && !options.host) {
+    location = this.proxyTable.getProxyLocation(req);
+
+    //
+    // If no location is returned from the ProxyTable instance
+    // then respond with `404` since we do not have a valid proxy target.
+    //
+    if (!location) {
+      res.writeHead(404);
+      return res.end();
+    }
+
+    //
+    // When using the ProxyTable in conjunction with an HttpProxy instance
+    // only the following arguments are valid:
+    //
+    // * `proxy.proxyRequest(req, res, { host: 'localhost' })`: This will be skipped
+    // * `proxy.proxyRequest(req, res, { buffer: buffer })`: Buffer will get updated appropriately
+    // * `proxy.proxyRequest(req, res)`: Options will be assigned appropriately.
+    //
+    options.port = location.port;
+    options.host = location.host;
+  }
+
+  //
   // Get the protocol, and host for this request and create an instance
   // of `http.Agent` or `https.Agent` from the pool managed by `node-http-proxy`.
   //


### PR DESCRIPTION
The following would not work, assuming a websocket request is sent, and local.host and sub.local.host can receive socket.io websocket requests:

``` javascript
httpProxy.createServer({
    hostnameOnly: true
  , router: {
        'local.host': 'localhost:3001'
      , 'sub.local.host': 'localhost:3002'
    }
}).listen(3000);
```

Even though there is a passing test for websocket proxying when using a routing table in your vows tests, that test does not provide complete coverage, since the test helper it uses passes a callback to httpProxy.createServer(...). When a callback is passed to createServer, then proxyWebSocketRequest is never called because the 'upgrade' event callback is only set up if a callback is passed into createServer. As a result, it does not end up catching this particular issue.
