### PR TITLE
Memory leak hunting

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -344,6 +344,13 @@ HttpProxy.prototype.buffer = function (obj) {
       obj.removeListener('data', onData);
       obj.removeListener('end', onEnd);
     },
+    destroy: function () {
+      this.end();
+      this.resume = function () {
+        console.error("Cannot resume buffer after destroying it.");
+      };
+      onData = onEnd = events = obj = null;
+    },
     resume: function () {
       this.end();
       for (var i = 0, len = events.length; i < len; ++i) {
@@ -586,8 +593,12 @@ HttpProxy.prototype.proxyRequest = function (req, res, options) {
   });
 
   // If we have been passed buffered data, resume it.
-  if (options.buffer && !errState) {
-    options.buffer.resume();
+  if (options.buffer) {
+    if (!errState) {
+      options.buffer.resume();
+    } else {
+      options.buffer.destroy();
+    }
   }
 };
 
@@ -733,6 +744,7 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
           reverseProxy.incoming.socket.write(data);
         }
         catch (e) {
+          detach();
           reverseProxy.incoming.socket.end();
           proxySocket.end();
         }
@@ -749,6 +761,7 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
         proxySocket.write(data);
       }
       catch (e) {
+        detach();
         proxySocket.end();
         socket.end();
       }
@@ -833,7 +846,6 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
     if (self.emit('webSocketProxyError', req, socket, head)) {
       return;
     }
-
     socket.end();
   }
 
@@ -932,10 +944,12 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
     proxyError(ex);
   }
 
-  //
   // If we have been passed buffered data, resume it.
-  //
-  if (options.buffer && !errState) {
-    options.buffer.resume();
+  if (options.buffer) {
+    if (!errState) {
+      options.buffer.resume();
+    } else {
+      options.buffer.destroy();
+    }
   }
 };


### PR DESCRIPTION
We saw the memory usage of the http proxy servers in no.de climb way up past normal levels after fixing the crash-inducing socket termination throws.  (Incidentally, that error was preventing this one from occurring.)

The attached patch makes sure to destroy the buffered request, and unhook event listeners, when there is an error.  So far today, the memory usage on the proxy with this patch has been stable.  The others continue to rise, occasionally hitting the point where they get forcibly HUP'ed.
