### PR TITLE
Add flow control

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -554,7 +554,11 @@ HttpProxy.prototype.proxyRequest = function (req, res, options) {
         //console.error('backpressure 554');
         response.pause();
         res.once('drain', function () {
-          response.resume();
+          try {
+            response.resume();
+          } catch (er) {
+            console.error("response.resume error: %s", er.message);
+          }
         });
         setTimeout(function () {
           res.emit('drain');
@@ -594,7 +598,11 @@ HttpProxy.prototype.proxyRequest = function (req, res, options) {
         //console.error('backpressure 594');
         req.pause();
         reverseProxy.once('drain', function () {
-          req.resume();
+          try {
+            req.resume();
+          } catch (er) {
+            console.error("req.resume error: %s", er.message);
+          }
         });
         setTimeout(function () {
           reverseProxy.emit('drain');
@@ -672,7 +680,11 @@ HttpProxy.prototype._forwardRequest = function (req) {
       //console.error('backpressure 672');
       req.pause();
       forwardProxy.once('drain', function () {
-        req.resume();
+        try {
+          req.resume();
+        } catch (er) {
+          console.error("req.resume error: %s", er.message);
+        }
       });
       setTimeout(function () {
         forwardProxy.emit('drain');
@@ -777,7 +789,11 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
             //console.error('backpressure 777');
             proxySocket.pause();
             reverseProxy.incoming.socket.once('drain', function () {
-              proxySocket.resume();
+              try {
+                proxySocket.resume();
+              } catch (er) {
+                console.error("proxySocket.resume error: %s", er.message);
+              }
             });
             setTimeout(function () {
               reverseProxy.incoming.socket.emit('drain');
@@ -804,7 +820,11 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
           //console.error('backpressure 804');
           reverseProxy.incoming.socket.pause();
           proxySocket.once('drain', function () {
-            reverseProxy.incoming.socket.resume();
+            try {
+              reverseProxy.incoming.socket.resume();
+            } catch (er) {
+              console.error("reverseProxy.incoming.socket.resume error: %s", er.message);
+            }
           });
           setTimeout(function () {
             proxySocket.emit('drain');
@@ -974,7 +994,11 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, options
           //console.error('backpressure 974');
           reverseProxy.socket.pause();
           socket.once('drain', function () {
-            reverseProxy.socket.resume();
+            try {
+              reverseProxy.socket.resume();
+            } catch (er) {
+              console.error("reverseProxy.socket.resume error: %s", er.message);
+            }
           });
           setTimeout(function () {
             socket.emit('drain');


### PR DESCRIPTION
Not in the "async/fibers/coro" sense of flow control, but in the TCP
backpressure sense.

Pause the stream when a write isn't flushed, and then resume it once the
writable stream drains.
