### PR TITLE
Fixed DoS vector in middleware implementation

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -125,11 +125,15 @@ exports.stack = function stack (middlewares, proxy) {
     handle = function (req, res) {
       var next = function (err) {
         if (err) {
-          throw err;
-          //
-          // TODO: figure out where to send errors.
-          // return error(req, res, err);
-          //
+          console.error(err.stack);
+          if (res._headerSent) {
+            res.destroy();
+          } else {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'text/plain');
+            res.end('Internal Server Error');
+          }
+          return;
         }
         child(req, res);
       }


### PR DESCRIPTION
it's pretty trivial to trigger a `next(err)` for almost any middleware, by-design they should be handled in some unified fashion, however the one in this lib just throws. You could also emit an error event with the req/res to conditionally allow users to customize the handling if necessary
