### PR TITLE
command line tool - make sure targetPort is an integer

### DIFF
--- a/bin/node-http-proxy
+++ b/bin/node-http-proxy
@@ -64,7 +64,7 @@ if (typeof target === 'string') location = target.split(':');
 //
 var server;
 if (location) {
-  var targetPort = location.length === 1 ? 80 : location[1];
+  var targetPort = location.length === 1 ? 80 : parseInt(location[1]);
   server = httpProxy.createServer(targetPort, location[0], config);
 }
 else if (config.router) {


### PR DESCRIPTION
This fixes a bug that caused cli to fail when --target was specified with both hostname and port
