### PR TITLE
added 'targetHeaders' and targetResponse' events for handling the response

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -207,9 +207,37 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
       if (req.headers.connection) { response.headers.connection = req.headers.connection }
       else { response.headers.connection = 'close' }
     }
-
-    // Set the headers of the client response
-    res.writeHead(response.statusCode, response.headers);
+    
+    var useDefault = false;
+    function setDefault() {
+      useDefault = true;
+    };
+    //
+    // Emit a `targetResponse` event, allowing the application to use custom
+    // headers handling. The error handler should write the headers using
+    // res.writeHead(statusCode, headers);
+    // if setDefault is called by a event handler, then the default headers,
+    // those coming from the server, will be used
+    //
+    if(self.emit('targetResponse', response, req, res, setDefault) && !useDefault) {
+      // If a custom response has been provided,
+      // aka at least one event handler is set and setDefault has not been called
+      // then nothing is left to be done
+      return;
+    }
+    
+    useDefault = false;
+    //
+    // Emit a `targetHeaders` event, allowing the application to use custom
+    // headers handling. The error handler should write the headers using
+    // res.writeHead(statusCode, headers);
+    // if setDefault is called by a event handler, then the default headers,
+    // those coming from the target, will be used
+    //
+    if(! self.emit('targetHeaders', response.statusCode, response.headers, req, res, setDefault) || useDefault) {
+      // By default, set the headers of the client response
+      res.writeHead(response.statusCode, response.headers);
+    }
 
     // If `response.statusCode === 304`: No 'data' event and no 'end'
     if (response.statusCode === 304) {

--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -92,6 +92,8 @@ RoutingProxy.prototype.add = function (options) {
   this.proxies[key] = new HttpProxy(options);
   this.proxies[key].on('proxyError', this.emit.bind(this, 'proxyError'));
   this.proxies[key].on('webSocketProxyError', this.emit.bind(this, 'webSocketProxyError'));
+  this.proxies[key].on('targetResponse', this.emit.bind(this, 'targetResponse'));
+  this.proxies[key].on('targetHeaders', this.emit.bind(this, 'targetHeaders'));
 };
 
 //


### PR DESCRIPTION
added 'targetHeaders' and targetResponse' events for handling the response header, or the whole response, using the target response.

It ables to make some smart error pages for all the (v)hosts a reverse-proxy handles
