### PR TITLE
[fix] Avoid `Transfer-Encoding: chunked` for HTTP/1.0 client

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -208,6 +208,11 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
       else { response.headers.connection = 'close' }
     }
 
+    // Remove `Transfer-Encoding` header if client's protocol is HTTP/1.0
+    if (req.httpVersion === '1.0') {
+      delete response.headers['transfer-encoding'];
+    }
+
     // Set the headers of the client response
     res.writeHead(response.statusCode, response.headers);
 


### PR DESCRIPTION
Refer to issue #59 and joyent/node#1234.

Simple test is [here](https://gist.github.com/1270121).
before:

```
$ node http10.js
HTTP/1.1 200 OK
connection: close
transfer-encoding: chunked

7
Hello, 
6
World

0


```

after:

```
$ node http10.js
HTTP/1.1 200 OK
connection: close

Hello, World

```
