### PR TITLE
change proxyTable routing target path

### DIFF
--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -135,16 +135,17 @@ ProxyTable.prototype.getProxyLocation = function (req) {
   else {
     target += req.url;
     for (var i in this.routes) {
-      var route = this.routes[i],
-          match;
-
-      if (match = target.match(route.route)) {
+      var route = this.routes[i];
+      if (target.match(route.route)) {
         
-        var root = "/" + route.path.split('/')[1];
-        var beginningSegment = new RegExp("^" + root);
+        var segments = route.path.split('/');
         
-        if(req.url.match(beginningSegment)) {
-          req.url = req.url.replace(beginningSegment, '');
+        if (segments.length > 0) {
+          var lastSegment = new RegExp("/" + segments[segments.length - 1] + "$");
+          
+          if(req.url.match(lastSegment)) {
+            req.url = req.url.replace(lastSegment, '/');
+          }          
         }
         
         var location = route.target.split(':'),

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -55,10 +55,12 @@ var TestRunner = exports.TestRunner = function (options) {
   }
 };
 
-TestRunner.prototype.assertProxied = function (host, proxyPort, port, createProxy) {
+TestRunner.prototype.assertProxied = function (host, proxyPort, port, requestPath, targetPath, createProxy) {
+  if (!targetPath) targetPath = "";
+  
   var self = this,
-      assertion = "should receive 'hello " + host + "'",
-      output = 'hello ' + host;
+      output = "hello " + host + targetPath,
+      assertion = "should receive '" + output + "'";
 
   var test = {
     topic: function () {
@@ -73,6 +75,7 @@ TestRunner.prototype.assertProxied = function (host, proxyPort, port, createProx
         }
       };
       
+      if (requestPath) options.uri += requestPath;
 
       function startTest () {
         if (port) {
@@ -80,7 +83,6 @@ TestRunner.prototype.assertProxied = function (host, proxyPort, port, createProx
             request(options, that.callback);
           });
         }
-
         request(options, this.callback);
       }
 

--- a/test/http/http-proxy-test.js
+++ b/test/http/http-proxy-test.js
@@ -51,7 +51,7 @@ var options = helpers.parseProtocol(),
 vows.describe('node-http-proxy/http-proxy/' + testName).addBatch({
   "When using server created by httpProxy.createServer()": {
     "with no latency" : {
-      "and a valid target server": runner.assertProxied('localhost', 8080, 8081, function (callback) {
+      "and a valid target server": runner.assertProxied('localhost', 8080, 8081, false, false, function (callback) {
         runner.startProxyServer(8080, 8081, 'localhost', callback);
       }),
       "and without a valid target server": runner.assertResponseCode(8082, 500, function (callback) {
@@ -59,7 +59,7 @@ vows.describe('node-http-proxy/http-proxy/' + testName).addBatch({
       })
     },
     "with latency": {
-      "and a valid target server": runner.assertProxied('localhost', 8083, 8084, function (callback) {
+      "and a valid target server": runner.assertProxied('localhost', 8083, 8084, false, false, function (callback) {
         runner.startLatentProxyServer(8083, 8084, 'localhost', 1000, callback);
       }),
       "and without a valid target server": runner.assertResponseCode(8085, 500, function (callback) {
@@ -71,13 +71,13 @@ vows.describe('node-http-proxy/http-proxy/' + testName).addBatch({
         runner.startTargetServer(8300, 'forward proxy', this.callback);
       },
       "with no latency" : {
-        "and a valid target server": runner.assertProxied('localhost', 8120, 8121, function (callback) {
+        "and a valid target server": runner.assertProxied('localhost', 8120, 8121, false, false, function (callback) {
           runner.startProxyServerWithForwarding(8120, 8121, 'localhost', forwardOptions, callback);
         }),
         "and also a valid target server": runner.assertHeaders(8122, "x-forwarded-for", function (callback) {
           runner.startProxyServerWithForwarding(8122, 8123, 'localhost', forwardOptions, callback);
         }),
-        "and without a valid forward server": runner.assertProxied('localhost', 8124, 8125, function (callback) {
+        "and without a valid forward server": runner.assertProxied('localhost', 8124, 8125, false, false, function (callback) {
           runner.startProxyServerWithForwarding(8124, 8125, 'localhost', badForwardOptions, callback);
         })
       }

--- a/test/http/routing-proxy-test.js
+++ b/test/http/routing-proxy-test.js
@@ -29,7 +29,9 @@ var fileOptions = {
 var defaultOptions = {
   router: {
     "foo.com": "127.0.0.1:8091",
-    "bar.com": "127.0.0.1:8092"
+    "bar.com": "127.0.0.1:8092",
+    "baz.com/taco": "127.0.0.1:8098",
+    "pizza.com/taco/muffins": "127.0.0.1:8099",
   }
 };
 
@@ -50,6 +52,8 @@ vows.describe('node-http-proxy/routing-proxy/' + testName).addBatch({
         },
         "an incoming request to foo.com": runner.assertProxied('foo.com', 8090, 8091),
         "an incoming request to bar.com": runner.assertProxied('bar.com', 8090, 8092),
+        "an incoming request to baz.com/taco": runner.assertProxied('baz.com', 8090, 8098, "/taco", "/"),
+        "an incoming request to pizza.com/taco/muffins": runner.assertProxied('pizza.com', 8090, 8099, "/taco/muffins", "/taco"),
         "an incoming request to unknown.com": runner.assertResponseCode(8090, 404)
       },
       "and routing by Hostname": {


### PR DESCRIPTION
given a proxyTable router like this:

```
{
  "baz.com/taco": "127.0.0.1:8098",
  "pizza.com/taco/muffins": "127.0.0.1:8099",
}
```

requests from `baz.com/taco` will get proxied to `127.0.0.1:8098` and requests from `pizza.com/taco/muffins` will get proxied to `127.0.0.1:8099/taco`

the old behavior was `baz.com/taco` to `127.0.0.1:8098/taco` and `pizza.com/taco/muffins` to `127.0.0.1:8099/taco/muffins`
