### PR TITLE
[fix] only set one drain listener while paused

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -224,6 +224,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     // If the res socket has been killed already, then write()
     // will throw. Nevertheless, try our best to end it nicely.
     //
+    var paused = false;
     response.on('data', function (chunk) {
       if (req.method !== 'HEAD' && res.writable) {
         try {
@@ -238,9 +239,11 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
           return;
         }
         
-        if (!flushed) {
+        if (!flushed && !paused) {
+          paused = true;
           response.pause();
           res.once('drain', function () {
+            paused = false;
             try { response.resume() } 
             catch (er) { console.error("response.resume error: %s", er.message) }
           });


### PR DESCRIPTION
Right now multiple .once calls can be done on paused streams, only one should be set.
