### PR TITLE
x-forwarded-for was always being set to 'undefined'. quick fix.

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -132,7 +132,12 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   if (this.enable.xforward && req.connection && req.socket) {
     req.headers['x-forwarded-for']   = req.connection.socket.remoteAddress || req.socket.socket.remoteAddress;
     req.headers['x-forwarded-port']  = req.connection.socket.remotePort || req.socket.socket.remotePort;
-    req.headers['x-forwarded-proto'] = req.connection.pair ? 'https' : 'http';
+    if (req.connection.pair) {
+        req.headers['x-forwarded-proto'] = 'https';  
+        req.headers['https'] = 'on'
+    } else {
+        req.headers['x-forwarded-proto'] = 'http';
+    };
   }
 
   //
@@ -367,7 +372,12 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
   if (this.enable.xforward && req.connection && req.connection.socket) {
     req.headers['x-forwarded-for']   = req.connection.socket.remoteAddress || req.connection.socket.socket.remoteAddress;
     req.headers['x-forwarded-port']  = req.connection.socket.remotePort || req.connection.socket.socket.remotePort;
-    req.headers['x-forwarded-proto'] = req.connection.pair ? 'https' : 'http';
+    if (req.connection.pair) {
+        req.headers['x-forwarded-proto'] = 'https';  
+        req.headers['https'] = 'on'
+    } else {
+        req.headers['x-forwarded-proto'] = 'http';
+    };
   }
 
   //


### PR DESCRIPTION
xforward settings undefined. It appears the socket that contains the details is one layer deeper.
