### PR TITLE
Update package.json, let npm install node-http-proxy in 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "test-http": "vows --spec && vows --spec --target=secure",
     "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure" 
   },
-  "engines": { "node": "0.4.x || 0.5.x" }
+  "engines": { "node": "0.4.x || 0.5.x || 0.6.x" }
 }


### PR DESCRIPTION
Just updating your package.json to enable installation under node 0.6.0
