### PR TITLE
Fixes memory leak when clients abort streamed connections

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -326,6 +326,13 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
   });
 
+  //Aborts reverseProxy if client aborts the connection.
+  req.on('close', function () {
+    if (!errState) {
+      reverseProxy.abort();
+    }
+  });
+
   //
   // If we have been passed buffered data, resume it.
   //


### PR DESCRIPTION
When clients abort streamed connections, I've been noticing that the correspondent connections against my backend services remain alive indefinitely. While doing research I wrote this piece of code that seems to solve the problem. All the existing tests are still passing. 
