### PR TITLE
Modified the ad-hoc proxy lookup to use _getKey(), rather than the error-prone in-line method.

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -180,8 +180,8 @@ RoutingProxy.prototype.proxyRequest = function (req, res, options) {
     options.host = location.host;
   }
   
-  var key = options.host + ':' + options.port,
-      proxy;
+  var key = this._getKey(options),
+    proxy;
   
   if (!this.proxies[key]) {
     this.add(options);
@@ -218,8 +218,8 @@ RoutingProxy.prototype.proxyWebSocketRequest = function (req, socket, head, opti
     options.host = location.host;
   }
   
-  var key = options.host + ':' + options.port,
-      proxy;
+  var key = this._getKey(options),
+    proxy;
 
   if (!this.proxies[key]) {
     this.add(options);


### PR DESCRIPTION
Modified the ad-hoc proxy lookup to use _getKey(), rather than the error-prone in-line method.

_getKey() will look for options.target as well as options.host:options.port, and so is useful for a segmented proxy server where the destination proxies are not constructed before first references.
