### PR TITLE
fixed comment typos in examples/http/proxy-https-to-http.js and proxy-ht...

### DIFF
--- a/examples/http/proxy-https-to-http.js
+++ b/examples/http/proxy-https-to-http.js
@@ -34,7 +34,7 @@ var https = require('https'),
 var opts = helpers.loadHttps();
 
 //
-// Crete the target HTTPS server 
+// Create the target HTTPS server 
 //
 http.createServer(function (req, res) {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -43,7 +43,7 @@ http.createServer(function (req, res) {
 }).listen(8000);
 
 //
-// Create the proxy server listening on port 443.
+// Create the proxy server listening on port 443
 //
 httpProxy.createServer(8000, 'localhost', {
   https: opts

--- a/examples/http/proxy-https-to-https.js
+++ b/examples/http/proxy-https-to-https.js
@@ -34,7 +34,7 @@ var https = require('https'),
 var opts = helpers.loadHttps();
 
 //
-// Crete the target HTTPS server 
+// Create the target HTTPS server 
 //
 https.createServer(opts, function (req, res) {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -43,7 +43,7 @@ https.createServer(opts, function (req, res) {
 }).listen(8000);
 
 //
-// Create the proxy server listening on port 443.
+// Create the proxy server listening on port 443
 //
 httpProxy.createServer(8000, 'localhost', {
   https: opts,


### PR DESCRIPTION
...tps-to-https.js, lines 37 and 46

(changed "Crete" to "Create")
(I had trouble rebasing on a previous fork so this is a new pull request from a fresh fork)
