### PR TITLE
Added an option to disable the URL rewrite when using proxy tables

### DIFF
--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -33,6 +33,7 @@ var util = require('util'),
 // #### @router {Object} Object containing the host based routes
 // #### @silent {Boolean} Value indicating whether we should suppress logs
 // #### @hostnameOnly {Boolean} Value indicating if we should route based on __hostname string only__
+// #### @rewriteURL {Boolean} Value indicating if we should remove the proxytable path segments in the proxied request url
 // Constructor function for the ProxyTable responsible for getting
 // locations of proxy targets based on ServerRequest headers; specifically
 // the HTTP host header.
@@ -42,6 +43,7 @@ var ProxyTable = exports.ProxyTable = function (options) {
 
   this.silent       = options.silent || options.silent !== true;
   this.hostnameOnly = options.hostnameOnly === true;
+  this.rewriteURL   = options.rewriteURL || options.rewriteURL !== false;
 
   if (typeof options.router === 'object') {
     //
@@ -139,7 +141,7 @@ ProxyTable.prototype.getProxyLocation = function (req) {
       if (target.match(route.route)) {
         var pathSegments = route.path.split('/');
         
-        if (pathSegments.length > 1) {
+        if (pathSegments.length > 1 && this.rewriteURL === true) {
           // don't include the proxytable path segments in the proxied request url
           pathSegments = new RegExp("/" + pathSegments.slice(1).join('/'));
           req.url = req.url.replace(pathSegments, '');


### PR DESCRIPTION
Ran into some problems when proxying HTTP to one place and Socket.IO traffic to another because of the URL rewrite, so added an option to disable it.
