### PR TITLE
Privilege drop support for bin/node-http-proxy via --user <username> parameter

### DIFF
--- a/bin/node-http-proxy
+++ b/bin/node-http-proxy
@@ -50,11 +50,11 @@ if (config.https) {
   Object.keys(config.https).forEach(function (key) {
     // If CA certs are specified, load those too.
     if (key === "ca") {
-      for (var i=0; i < key.length; i++) {
+      for (var i=0; i < config.https.ca.length; i++) {
         if (config.https.ca === undefined) {
-          config.https.ca = []
+          config.https.ca = [];
         }
-        config.https.ca.push(fs.readFileSync(key[i], 'utf8'));
+        config.https.ca[i] = fs.readFileSync(config.https[key][i], 'utf8');
       }
     } else {
       config.https[key] = fs.readFileSync(config.https[key], 'utf8');


### PR DESCRIPTION
Problem: Don't want to run my standalone proxy server as root to bind to privileged ports (e.g. 80, 443).

Solution: support privilege drop after socket bind via new --user <username> parameter.

Example:

sudo node-http-proxy --user nobody --port 80 --target localhost:3000
