### PR TITLE
Multiple random destinations

### DIFF
--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -122,8 +122,12 @@ ProxyTable.prototype.getProxyLocation = function (req) {
   var target = req.headers.host.split(':')[0];
   if (this.hostnameOnly == true) {
     if (this.router.hasOwnProperty(target)) {
-      var location = this.router[target].split(':'),
-          host = location[0],
+      var location = this.router[target];
+      if(util.isArray(location)) {
+		    location = location[Math.floor(Math.random()*location.length)];
+	    }
+	    location = location.split(':');
+      var host = location[0],
           port = location.length === 1 ? 80 : location[1];
 
       return {
@@ -145,8 +149,12 @@ ProxyTable.prototype.getProxyLocation = function (req) {
           req.url = req.url.replace(pathSegments, '');
         }
         
-        var location = route.target.split(':'),
-            host = location[0],
+        var location = route.target;
+  	    if(util.isArray(location)) {
+		      location = location[Math.floor(Math.random()*location.length)];
+		    }
+		    location = location.split(':');
+		    var host = location[0],
             port = location.length === 1 ? 80 : location[1];
 
         return {


### PR DESCRIPTION
We required the proxy table supports multiple random destinations for each configured request target.

var http = require('http'),
    httpProxy = require('http-proxy');

var options = {
    router: {
        '192.168.99.29': ['127.0.0.1:8000','127.0.0.1:9000']
    }
};

var proxyServer = httpProxy.createServer(options);
proxyServer.listen(80);

http.createServer(function (req, res) {
    res.writeHead(200, { 'Content-Type': 'text/plain' });
    res.write('request successfully proxied to srv1: ' + req.url +'\n' + JSON.stringify(req.headers, true, 2));
    res.end();
}).listen(8000);

http.createServer(function (req, res) {
    res.writeHead(200, { 'Content-Type': 'text/plain' });
    res.write('request successfully proxied to srv2: ' + req.url +'\n' + JSON.stringify(req.headers, true, 2));
    res.end();
}).listen(9000); 
