### PR TITLE
Route-specific parameters into routes table & rewriteURL param

### DIFF
--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -102,7 +102,8 @@ ProxyTable.prototype.setRoutes = function (router) {
       self.routes.push({
         route: route,
         target: router[path].target,
-        path: path
+        path: path,
+        rewriteURL: router[path].rewriteURL === true    //If not specified, i do not perform rewriting
       });
     });
   }
@@ -139,7 +140,7 @@ ProxyTable.prototype.getProxyLocation = function (req) {
       if (target.match(route.route)) {
         var pathSegments = route.path.split('/');
         
-        if (pathSegments.length > 1) {
+        if (pathSegments.length > 1 && route.rewriteURL) {
           // don't include the proxytable path segments in the proxied request url
           pathSegments = new RegExp("/" + pathSegments.slice(1).join('/'));
           req.url = req.url.replace(pathSegments, '');


### PR DESCRIPTION
Using node-http-proxy I ran into need of perform URL rewriting only for some of the routes specified into routes table.
I have implemented the possibility of specify multiple parameters for every route of the routes table and configured a new "rewriteURL" parameter that permits to conditionally check if the URL rewriting must be performed or not for  the matched entry of the routes table.

In this way, the routes must be specified as follows:

router: {
    'www.example.com/route1': { target:'127.0.0.1:8000' },
     //For the following entry I need to perform rewriting:
    'www.example.com/route2': { target:'127.0.0.1:8001', rewriteURL:true},
    'www.example.com': { target:'127.0.0.1:3000' }
  }

For my needs, this feature is very useful! I hope that will be useful for others too!
