### PR TITLE
lock down to socket.io 0.6.17 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "request": "1.9.x",
     "vows": "0.5.x",
     "async": "0.1.x",
-    "socket.io": "0.6.x"
+    "socket.io": "0.6.17"
   },
   "main": "./lib/node-http-proxy",
   "bin": { "node-http-proxy": "./bin/node-http-proxy" },


### PR DESCRIPTION
- socket.io 0.6.18 seems to be broken:
  
  ```
  % npm install
  npm http GET https://registry.npmjs.org/vows
  npm http GET https://registry.npmjs.org/request
  npm http GET https://registry.npmjs.org/socket.io
  npm http GET https://registry.npmjs.org/async
  npm http 304 https://registry.npmjs.org/vows
  npm http 304 https://registry.npmjs.org/socket.io
  npm http 304 https://registry.npmjs.org/request
  npm http 304 https://registry.npmjs.org/async
  npm http GET https://registry.npmjs.org/socket.io/-/socket.io-0.6.18.tgz
  npm http 200 https://registry.npmjs.org/socket.io/-/socket.io-0.6.18.tgz
  
  npm ERR! SyntaxError: Unexpected token }
  npm ERR!     at Object.parse (native)
  npm ERR!     at Packer.readRules (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/fstream-npm.js:174:31)
  npm ERR!     at Packer.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:132:22)
  npm ERR!     at [object Object].<anonymous> (fs.js:115:5)
  npm ERR!     at [object Object].emit (events.js:64:17)
  npm ERR!     at afterRead (fs.js:1117:12)
  npm ERR!     at Object.wrapper [as oncomplete] (fs.js:254:17)
  npm ERR! You may report this log at:
  npm ERR!     <http://github.com/isaacs/npm/issues>
  npm ERR! or email it to:
  npm ERR!     <npm-@googlegroups.com>
  npm ERR!
  npm ERR! System Darwin 11.3.0
  npm ERR! command "node" "/usr/local/bin/npm" "install"
  npm ERR! cwd /Users/bts/code/github/node-http-proxy
  npm ERR! node -v v0.6.14
  npm ERR! npm -v 1.1.16
  npm ERR! type unexpected_token
  npm ERR! arguments [ '}' ]
  npm ERR! message Unexpected token }
  npm ERR!
  npm ERR! Additional logging details can be found in:
  npm ERR!     /Users/bts/code/github/node-http-proxy/npm-debug.log
  npm not ok
  ```

Here are some others affected by this issue: https://gist.github.com/2387930
