### PR TITLE
prefer `target.hostname` over `target.host`

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -209,12 +209,13 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   //
   // Setup outgoing proxy with relevant properties.
   //
-  outgoing.host    = this.target.host;
-  outgoing.port    = this.target.port;
-  outgoing.agent   = this.target.agent;
-  outgoing.method  = req.method;
-  outgoing.path    = req.url;
-  outgoing.headers = req.headers;
+  outgoing.host     = this.target.host;
+  outgoing.hostname = this.target.hostname;
+  outgoing.port     = this.target.port;
+  outgoing.agent    = this.target.agent;
+  outgoing.method   = req.method;
+  outgoing.path     = req.url;
+  outgoing.headers  = req.headers;
 
   //
   // Open new HTTP request to internal resource with will act 


### PR DESCRIPTION
Hi, 

I struggled to debug an `Error: getaddrinfo ENOENT`.

I parsed my target string with `url`

```
> require('url').parse('http://127.0.0.1:3000/')
{ protocol: 'http:',
  slashes: true,
  host: '127.0.0.1:3000',
  port: '3000',
  hostname: '127.0.0.1',
  href: 'http://127.0.0.1:3000/',
  pathname: '/',
  path: '/' }
```

And pass this object to `node-http-proxy`. 

Then the following code is executed : 

```
outgoing.host    = this.target.host;
outgoing.port    = this.target.port;

reverseProxy = this.target.protocol.request(outgoing, function (response) {
```

But host === '127.0.0.1:3000', and it fails.

That's why I would prefer 

```
outgoing.hostname    = this.target.hostname;
```

because hostname always === '127.0.0.1'

This is also a nodejs recommendation: 

http://nodejs.org/api/http.html#http_http_request_options_callback

> host: A domain name or IP address of the server to issue the request to. Defaults to 'localhost'.
> hostname: To support url.parse() hostname is preferred over host
