### PR TITLE
Add path only routes

### DIFF
--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -136,7 +136,7 @@ ProxyTable.prototype.getProxyLocation = function (req) {
     target += req.url;
     for (var i in this.routes) {
       var route = this.routes[i];
-      if ((route.path.slice(0, 1) == '/' && request.url.match(route.route)
+      if ((route.path.slice(0, 1) == '/' && req.url.match(route.route))
 	   || target.match(route.route)) {
         var pathSegments = route.path.split('/');
         


### PR DESCRIPTION
Small patch to detect if a route path begins with a slash (/) and if so treat it as a path only route, e.g. we don't care about routing via hostname.

This because for our own purposes we only need to route from a single thin layer server, with paths defining routing (e.g. /bar => bar.example.com, /baz => baz.example.com, /foo/test?q= => foo.example.com/test?q= etc.).

Given the simple slice and match required I think this should make a negligible production performance difference and there must be other peeps out there with this use case.
