### PR TITLE
Implement RoutingProxy.prototype.remove

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -120,7 +120,11 @@ RoutingProxy.prototype.add = function (options) {
 // for the specified `options.host` and `options.port` (if they exist).
 //
 RoutingProxy.prototype.remove = function (options) {
-  var key = this._getKey(options);
+  var key = this._getKey(options),
+      proxy = this.proxies[key];
+
+  delete this.proxies[key];
+  return proxy;
 };
 
 //


### PR DESCRIPTION
Returns the proxy object so we can call the close method. Maybe it should be possible to set a flag that will automatically do it?
