### PR TITLE
Add HTTP Host header on request proxy to ensure virtualhost targets work as expected

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -156,6 +156,10 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
   }
 
+  // Add HTTP "Host:" header to ensure if target is a
+  // virtualhost it will still work as expected.
+  req.headers.host = this.target.host;
+
   //
   // Emit the `start` event indicating that we have begun the proxy operation.
   //


### PR DESCRIPTION
While readme suggests that path based proxying can't be used with Host header, and that's why Host is only used with host based routing, there is nothing stopping us adding the Host HTTP header for each request, from the target host, to ensure virtualhost targets still work as expected.
