### PR TITLE
Possible memory leak?

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -214,7 +214,15 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   outgoing.agent   = this.target.agent;
   outgoing.method  = req.method;
   outgoing.path    = req.url;
-  outgoing.headers = req.headers;
+  outgoing.headers = {};
+
+  for (var attr in req.headers) {
+      if(req.headers.hasOwnProperty(attr)) {
+          outgoing.headers[attr] = req.headers[attr];
+      }
+  }
+
+
 
   //
   // Open new HTTP request to internal resource with will act 


### PR DESCRIPTION
Do not keep a reference of the req object through the
req.headers object. Create a copy of the headers object instead.

Could you maybe check this? I'm trying to use node-http-proxy in a production env. but in 30 minutes and 200 req/s the app is out of memory. I tried to profile the app with node-webkit-agent. I suspect the following line to be part of the problem. I'm not 100% sure...

Best Regards
Philipp
