### PR TITLE
x-forwarded-proto has wrong value

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -148,7 +148,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
 
     if (req.headers['x-forwarded-proto']){
-      var protoToAppend = "," + req.connection.pair ? 'https' : 'http';
+      var protoToAppend = "," + (req.connection.pair) ? 'https' : 'http';
       req.headers['x-forwarded-proto'] += protoToAppend;
     } 
     else {
@@ -415,7 +415,7 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
     }
 
     if (req.headers['x-forwarded-proto']){
-      var protoToAppend = "," + req.connection.pair ? 'wss' : 'ws';
+      var protoToAppend = "," + (req.connection.pair) ? 'wss' : 'ws';
       req.headers['x-forwarded-proto'] += protoToAppend;
     } 
     else {


### PR DESCRIPTION
The ternary was evaluating truthy for "," + req.connection.pair which is always true because its always a non empty string.  Wrapped actual condition to properly concatenate the product of the ternary.  let me know if you prefer the style   (req.connection.pair ? 'https' : 'http')

https://github.com/nodejitsu/node-http-proxy/issues/250
