### PR TITLE
Don't override 'connection' header if was set by the target server

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -244,7 +244,10 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
 
     // Set the headers of the client response
-    res.writeHead(response.statusCode, response.headers);
+    Object.keys(response.headers).forEach(function(key){
+      res.setHeader(key, response.headers[key]);
+    });
+    res.writeHead(response.statusCode);
 
     // If `response.statusCode === 304`: No 'data' event and no 'end'
     if (response.statusCode === 304) {


### PR DESCRIPTION
In http-proxy.js line 227 - if the original request didn't have a 'connection' header, and the target server set this header to any value, it will always be overridden and set to 'close'.
This proposed fix set the connection header only if not already set by the target server.
