### PR TITLE
Fix bug: x-forwarded-proto set incorrectly as httphttps or wswss

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -148,7 +148,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
 
     if (req.headers['x-forwarded-proto']){
-      var protoToAppend = "," + (req.connection.pair) ? 'https' : 'http';
+      var protoToAppend = "," + (req.connection.pair ? 'https' : 'http');
       req.headers['x-forwarded-proto'] += protoToAppend;
     } 
     else {
@@ -415,7 +415,7 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
     }
 
     if (req.headers['x-forwarded-proto']){
-      var protoToAppend = "," + (req.connection.pair) ? 'wss' : 'ws';
+      var protoToAppend = "," + (req.connection.pair ? 'wss' : 'ws');
       req.headers['x-forwarded-proto'] += protoToAppend;
     } 
     else {


### PR DESCRIPTION
When routed via multiple proxies, x_forwarded_proto set as httphttps or
wswss instead of http,https or ws,wss, since + operator seems to have a
higher precedence than the terniary operator and the expression was
getting evaluated to true always
