### PR TITLE
Add support for setting the host in the executable

### DIFF
--- a/bin/node-http-proxy
+++ b/bin/node-http-proxy
@@ -79,10 +79,10 @@ else {
 //
 // Start the server
 //
-if (!host) {
-  server.listen(port);
-} else {
+if (host) {
   server.listen(port, host);
+} else {
+  server.listen(port);
 }
 
 //


### PR DESCRIPTION
This patch adds support for a host to be set with the node-http-proxy executable. It adds the `--host` argument meaning you can do

```
node-http-proxy --config config.json --host 192.168.3.37
```

My use case is that I have a server that has the following IP addresses assigned to it
- 192.168.3.5
- 192.168.3.37

Port 80 on 192.168.3.5 is used by Nginx and I want to use port 80 on 192.168.3.37 for node-http-proxy. Without the patch the executable binds to INADDR_ANY and because Nginx is already listening to port 192.168.3.5:80 I get

```
Error: listen EADDRINUSE
```
