### PR TITLE
If supplied pass changeOrigin option through to HttpProxy instance if set in RoutingProxy

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -51,6 +51,7 @@ var RoutingProxy = exports.RoutingProxy = function (options) {
   this.https   = this.source.https || options.https;
   this.enable  = options.enable;
   this.forward = options.forward;
+  this.changeOrigin = options.changeOrigin || false;
 
   //
   // Listen for 'newListener' events so that we can bind 'proxyError'
@@ -94,7 +95,7 @@ RoutingProxy.prototype.add = function (options) {
   // Setup options to pass-thru to the new `HttpProxy` instance
   // for the specified `options.host` and `options.port` pair.
   //
-  ['https', 'enable', 'forward'].forEach(function (key) {
+  ['https', 'enable', 'forward', 'changeOrigin'].forEach(function (key) {
     if (options[key] !== false && self[key]) {
       options[key] = self[key];
     }


### PR DESCRIPTION
We use a standalone `httpProxy.RoutingProxy` instance inside our app to handle adhoc HTTP proxy requests. The `changeOrigin` option re-added in 0.8.2 isn't passed through to `httpProxy.HttpProxy` instances when passed to routing proxy instances, so I've tried to match the current way options are passed on in this patch.
