### PR TITLE
Handshake data flush bug

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -680,7 +680,7 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
         sdata = sdata.replace('ws:', 'wss:');
         data = new Buffer(Buffer.byteLength(sdata)+bdata.length);
         data.write(sdata, 0, Buffer.byteLength(sdata), 'utf8');
-        data.write(bdata, Buffer.byteLength(sdata), bdata.length, 'binary');
+        bdata.copy(data, Buffer.byteLength(sdata), 0, bdata.length);
       }
 
       try {


### PR DESCRIPTION
The steps to reproduce the issue are somewhat complex, but we encountered it when proxying concurrently to many different back-end servers.  Somewhere between 30 and 50% of the time the handshake would get corrupted.  It appears that the assumption was being made that if the second socket.write had been flushed, the first one would have been flushed as well - but that apparently that is not always the case or perhaps, because noDelay is set they were being split into separate responses instead of as the single response they are supposed to be?  Either way, the source of the problem was the double socket.write that was being done to push the string data and the binary data.

I condensed these into a single write by reconstructing the buffer if modifications were necessary and the handshake failures seem to have stopped.
