### PR TITLE
Memory leak fix in forwarding of websockets

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -546,24 +546,31 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
       reverseProxy.incoming.socket.removeListener('data', listeners.onOutgoing);
     }
 
-    //
+   //
     // If the incoming `proxySocket` socket closes, then
     // detach all event listeners.
     //
-    proxySocket.on('end', listeners.onIncomingClose = function() {
+    listeners.onIncomingClose = function() {
+      reverseProxy.incoming.socket.destroy();
       detach();
 
       // Emit the `end` event now that we have completed proxying
-      self.emit('websocket:end', req, socket, head);
-    });
+      self.emit('websocket:end', req, socket, head);    
+    }
 
     //
     // If the `reverseProxy` socket closes, then detach all
     // event listeners.
-    //
-    reverseProxy.incoming.socket.on('end', listeners.onOutgoingClose = function() {
-      detach();
-    });
+    //    
+    listeners.onOutgoingClose = function() {
+      proxySocket.destroy();
+      detach();   
+    }
+
+    proxySocket.on('end', listeners.onIncomingClose);
+    proxySocket.on('close', listeners.onIncomingClose);
+    reverseProxy.incoming.socket.on('end', listeners.onOutgoingClose);
+    reverseProxy.incoming.socket.on('close', listeners.onOutgoingClose);
   }
 
   function getPort (port) {


### PR DESCRIPTION
Http-proxy has a big memory leak when forwarding websockets. Test case: socket.io client establishes websocket to a socket.io server, via http-proxy. The client holds the connection for some time (e.g. 10 sec), closes the connection, establishes another one, holds it open for a while, closes, etc. in a loop. Use several hundred clients to observe a consistent memory growth,  hundreds of MB in a few minutes. Garbage collection  does not reclaim the lost memory.

The fix is in node-http-proxy/http-poxy.js by registering on 'close' handlers of incoming and outgoing socket, in addition to already present on 'end' handlers. The test case described above stopped leaking memory completely after applying this fix. 

Repro test case can be made available upon request.
