### PR TITLE
If HTTP 1.1 is used and backend doesn't return 'Connection' header, expicitly  return Connection: keep-alive.

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -236,7 +236,14 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     //
     if (response.headers.connection) {
       if (req.headers.connection) { response.headers.connection = req.headers.connection }
-      else { response.headers.connection = 'close' }
+      else {
+        if (req.httpVersion === '1.0') {
+          response.headers.connection = 'close'
+        }
+        else if (req.httpVersion === '1.1') {
+          response.headers.connection = 'keep-alive'
+        }
+      }
     }
 
     // Remove `Transfer-Encoding` header if client's protocol is HTTP/1.0


### PR DESCRIPTION
Currently if a backend doesn't return `Connection` header, http-proxy sets it to `Connetion: close` regardless  of the request HTTP version.

We should respect request HTTP version and if HTTP 1.1 is used, return `Connection: keep-alive`. *
- Quoted from the [RFC](http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection):

```
...
to indicate that the connection will be kept open for the next request. The Connection header field with a keep-alive keyword must be sent on all requests and responses that wish to continue the persistence. The client sends requests as normal and the server responds as normal, except that all messages containing an entity body must have a length that can be determined without closing the connection (i.e., each message containg an entity body must have a valid Content-Length, be a multipart media type, or be encoded using the "chunked" transfer coding, as described in Section 7.2.2).
...
```
