### PR TITLE
Set the content-type header prior to writing the rest of the headers (fixes #316)

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -257,7 +257,12 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
 
     // Set the headers of the client response
-    res.writeHead(response.statusCode, response.headers);
+    for (var key in response.headers) {
+      if (response.headers.hasOwnProperty(key)) {
+        res.setHeader(key, response.headers[key]);
+      }
+    }
+    res.writeHead(response.statusCode);
 
     // If `response.statusCode === 304`: No 'data' event and no 'end'
     if (response.statusCode === 304) {


### PR DESCRIPTION
This allows the connect.compress() middleware to work on proxied requests.

If this header is not manually set then the compress middleware will be invoked in the writeHead() call:

  https://github.com/nodejitsu/node-http-proxy/blob/1df2b30e84f078d86e744601bd6fc59381a1c7b3/lib/node-http-proxy/http-proxy.js#L260

before the header has been written. Therefore it will perform its content-type check:

  https://github.com/senchalabs/connect/blob/7b5621b8dd4d9d82296b9b5d7bf3bea10de37a6c/lib/middleware/compress.js#L94

and so the check will fail and compression will be disabled.
