### PR TITLE
No longer necessary to treat 304 responses specially.

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -259,13 +259,6 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     // Set the headers of the client response
     res.writeHead(response.statusCode, response.headers);
 
-    // If `response.statusCode === 304`: No 'data' event and no 'end'
-    if (response.statusCode === 304) {
-      try { res.end() }
-      catch (ex) { console.error("res.end error: %s", ex.message) }
-      return;
-    }
-
     function ondata(chunk) {
       if (res.writable) {
         if (false === res.write(chunk) && response.pause) {


### PR DESCRIPTION
The end event should also be emitted for 304 (Not modified) responses.

Starting with commit 182dcd34555f361c1bb2b8d2777689e64ce32f87, there is no need to special handle these response statuses.

Ensures that end is emitted also for 304 responses.
