### PR TITLE
Fix truncated chunked responses

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -310,7 +310,6 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     //
     response.connection.on('end', function () {
       if (response.readable && response.resume) {
-      {
         response.resume();
       }
     });


### PR DESCRIPTION
This patch fixes a edge case bug, which randomly causes chunked transfers to be silently truncated.

The scenario is the following:
- a "slow" client tries to fetch a "big" resource, served by a backend server in chunked encoding
- since the client is slower than the backend, node-http-proxy will pause the response stream
- when reaching the end of the chunked response, the underlying socket will emit a 'end' event
- this 'end' event will terminate the response stream; pending events (i.e. the data received between the pause and the EOF) will be silently discarded
- the amount of queued data depends of the speed and latency of both client and backend connections, so it is pretty random, making the bug pretty hard to debug

The bug was particularly visible in the following conditions:
- client = typical DSL/cable consumer link on the West Coast
- proxy and server = EC2 instances in us-east-1
- resource = ~160 KB JS file, served gzipped+chunked by nginx (size: ~60 KB after compression)

The problem appears only when the response is chunked; probably because when a Content-Type is present, the HTTP module will fetch only the required amount of data, and therefore not hit EOF.

I'm not extremely satisfied with this fix because it doesn't feel very clean; so feel free to provide a better solution. It might involve changing things in Node.js libraries themselves, but I didn't feel like doing that myself, having virtually zero experience with Node.js.

Alternatively, the issue can be avoided by removing the response throttling, i.e. not calling pause; but then it becomes trivial to DOS the server by memory exhaustion by retrieving a very big resource with a (artificially) slow client.
