### PR TITLE
Not Found Handler

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -52,6 +52,7 @@ var RoutingProxy = exports.RoutingProxy = function (options) {
   this.enable  = options.enable;
   this.forward = options.forward;
   this.changeOrigin = options.changeOrigin || false;
+  this.notFoundHandler = options.notFoundHandler || false;
 
   //
   // Listen for 'newListener' events so that we can bind 'proxyError'
@@ -194,8 +195,13 @@ RoutingProxy.prototype.proxyRequest = function (req, res, options) {
     //
     if (!location) {
       try {
-        res.writeHead(404);
-        res.end();
+
+        if (this.notFoundHandler) {
+          this.notFoundHandler(req, res);
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
       }
       catch (er) {
         console.error("res.writeHead/res.end error: %s", er.message);


### PR DESCRIPTION
What happens when a request comes to the server that does not match a host in the proxy table? Right now, it always responds with a 404.

I added the ability to define a custom function to fire to handle these events.

Please let me know if you think this is an improvement and if you need any tests or formatting changes to include it.

Thanks,
Breck
