### PR TITLE
SPDY Support

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -27,6 +27,7 @@
 var util = require('util'),
     http = require('http'),
     https = require('https'),
+    spdy = require('spdy'),
     events = require('events'),
     maxSockets = 100;
 
@@ -174,9 +175,14 @@ exports.createServer = function () {
     ? exports.stack(handlers, proxy)
     : function (req, res) { handlers[0](req, res, proxy) };
   
-  server  = options.https
-    ? https.createServer(options.https, handler)
-    : http.createServer(handler);
+  options.spdy = options.spdy || true;
+  if(options.spdy){
+    server = spdy.createServer(options.https, handler)
+  } else{
+    server  = options.https
+      ? https.createServer(options.https, handler)
+      : http.createServer(handler);
+  }
 
   server.on('close', function () {
     proxy.close();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "http"
   ],
   "dependencies": {
+    "spdy" : "1.x.x",
     "colors": "0.x.x",
     "optimist": "0.3.x",
     "pkginfo": "0.2.x"


### PR DESCRIPTION
I think I've got SPDY working on the https proxy.

It uses node-spdy to do the actual spdy stuff, but when testing with the https-to-https example Chrome flags SPDY is working
