### PR TITLE
Path should always be a path, not a URL.

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -27,6 +27,7 @@
 var events = require('events'),
     http = require('http'),
     util = require('util'),
+    url = require('url'),
     httpProxy = require('../node-http-proxy');
 
 //
@@ -217,7 +218,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   outgoing.port     = this.target.port;
   outgoing.agent    = this.target.agent;
   outgoing.method   = req.method;
-  outgoing.path     = req.url;
+  outgoing.path     = url.parse(req.url).path;
   outgoing.headers  = req.headers;
 
   //
@@ -596,7 +597,7 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
   outgoing.port    = this.target.port;
   outgoing.agent   = agent;
   outgoing.method  = 'GET';
-  outgoing.path    = req.url;
+  outgoing.path    = url.parse(req.url).path;
   outgoing.headers = req.headers;
   outgoing.agent   = agent;
 
@@ -787,7 +788,7 @@ HttpProxy.prototype._forwardRequest = function (req) {
   outgoing.port    = this.forward.port,
   outgoing.agent   = this.forward.agent;
   outgoing.method  = req.method;
-  outgoing.path    = req.url;
+  outgoing.path    = url.parse(req.url).path;
   outgoing.headers = req.headers;
 
   //


### PR DESCRIPTION
When proxying to an app that is rather strict about it's HTTP headers, I was finding that the path was being set to the URL, causing 404 responses.

I've checked this does not break any of the vows, but I can't figure out how to test this in an acceptable way.

Any ideas?
