### PR TITLE
X-Forwarded-* headers

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -176,6 +176,7 @@ RoutingProxy.prototype.close = function () {
 //
 RoutingProxy.prototype.proxyRequest = function (req, res, options) {
   options = options || {};
+  
   var location;
 
   //


### PR DESCRIPTION
When using a routing table the x-forwarded-\* headers aren't send to the destination server. I synced with http-proxy's file and now it is working properly.

regards,
Otávio Ribeiro
