### PR TITLE
websocket not sending x-forwarded-for header

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -176,6 +176,7 @@ RoutingProxy.prototype.close = function () {
 //
 RoutingProxy.prototype.proxyRequest = function (req, res, options) {
   options = options || {};
+  
   var location;
 
   //


### PR DESCRIPTION
The problem was with websocket only. The req.connection.socket was always null and x-forwarded-for was never sent.
