### PR TITLE
Uncatchable error when upstream server returns malformed HTTP response

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -301,6 +301,16 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
 
     response.on('data', ondata);
 
+    // Work around Node issue 3776:
+    // https://github.com/joyent/node/issues/3776
+    // Since response is not exposed to callers of proxyRequest, it's not
+    // possible for them to perform this workaround themselves.
+    if (response.connection) {
+      response.connection.on('error', function(err) {
+        req.emit('error', err);
+      });
+    }
+
     function ondrain() {
       if (response.readable && response.resume) {
         response.resume();


### PR DESCRIPTION
Without this commit, Node versions 0.9.1 and earlier cause the process to
terminate with no recourse if upstream HTTP servers return malformed HTTP
responses.

Fixes issue #347
