### PR TITLE
Extend emitted events to accommodate caching layer

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -302,7 +302,6 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
           response.pause();
         }
       }
-      self.emit('data', chunk, req);
     }
 
     response.on('data', ondata);


### PR DESCRIPTION
I am implementing a caching layer on top of http-proxy and without these changes see no good way to intercept the upstream response so that it can be stored in a cache or replace a 304 response with a 200 response or manipulate headers in a few places. None of these changes will break backwards compatibility.

Note, the caching proxy layer is fully implemented but is still in beta: colinmollenhour/node-caching-proxy
