### PR TITLE
http-proxy should not modify the protocol in redirect request for external sites.

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -27,6 +27,7 @@
 var events = require('events'),
     http = require('http'),
     util = require('util'),
+    url = require('url'),
     httpProxy = require('../node-http-proxy');
 
 //
@@ -228,7 +229,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   if (this.changeOrigin) {
     outgoing.headers.host = this.target.host + ':' + this.target.port;
   }
-  
+
   //
   // Open new HTTP request to internal resource with will act
   // as a reverse proxy pass
@@ -248,11 +249,15 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
 
     if ((response.statusCode === 301) || (response.statusCode === 302)) {
-      if (self.source.https && !self.target.https) {
-        response.headers.location = response.headers.location.replace(/^http\:/, 'https:');
-      }
-      if (self.target.https && !self.source.https) {
-        response.headers.location = response.headers.location.replace(/^https\:/, 'http:');
+      // Only change protocol if url under target host
+      var parsedLocation = url.parse(response.headers.location);
+      if (parsedLocation.host === req.headers.host) {
+        if (self.source.https && !self.target.https) {
+          response.headers.location = response.headers.location.replace(/^http\:/, 'https:');
+        }
+        if (self.target.https && !self.source.https) {
+          response.headers.location = response.headers.location.replace(/^https\:/, 'http:');
+        }
       }
     }
 


### PR DESCRIPTION
In some cases, the target site may redirect the request to external url
which is not our proxying target. It is better not to modify the
protocol in this case.
