### PR TITLE
routing proxy 'this' reference bug?

### DIFF
--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -60,7 +60,7 @@ var RoutingProxy = exports.RoutingProxy = function (options) {
   this.on('newListener', function (evt) {
     if (evt === 'proxyError' || evt === 'webSocketProxyError') {
       Object.keys(self.proxies).forEach(function (key) {
-        self.proxies[key].on(evt, this.emit.bind(this, evt));
+        self.proxies[key].on(evt, self.emit.bind(self, evt));
       });
     }
   });


### PR DESCRIPTION
I think this was a bug in the RoutingProxy listener binding code. But I'm not sure. Anyway, it works better for me now in my application, where I'm binding multiple "once" listeners to a single proxy.
