### PR TITLE
Do not use "Transfer-Encoding: chunked" header for proxied DELETE requests.

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -247,6 +247,11 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
       delete response.headers['transfer-encoding'];
     }
 
+    // Do not use Transfer-Encoding for DELETE
+    if (req.method == 'DELETE') {
+      delete response.headers['transfer-encoding'];
+    }
+
     if ((response.statusCode === 301) || (response.statusCode === 302)) {
       if (self.source.https && !self.target.https) {
         response.headers.location = response.headers.location.replace(/^http\:/, 'https:');


### PR DESCRIPTION
We hit an issue with this node proxy. Webkit-based
browsers do not send Content-Length header when there
is no content for DELETE. DELETE requests have no
content, which causes node-http-proxy to add a
"Transfer-Encoding: chunked" header. This causes any
upstream Nginx server to fail with a 411.

```
Changes with nginx 0.3.12                26 Nov 2005

*) Bugfix: if the client sent the
   "Transfer-Encoding: chunked" header
   line, then nginx returns the 411 error.
```
