### PR TITLE
fixed issue #364 'proxyError' event emitted twice

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -312,14 +312,6 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   // Handle 'error' events from the `reverseProxy`.
   //
   reverseProxy.once('error', proxyError);
-  //
-  // NOT needed as node.js re-emits the socket errors as ClientRequest 'error'
-  // Look for socketErrorListener references in
-  // https://github.com/joyent/node/blob/master/lib/http.js
-  //
-  // reverseProxy.once('socket', function (socket) {
-  //   socket.once('error', proxyError);
-  // });
 
   //
   // Handle 'error' events from the `req` (e.g. `Parse Error`).
@@ -725,14 +717,6 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
       }
 
       //
-      // NOT needed as node.js re-emits the socket errors as ClientRequest 'error'
-      // Look for socketErrorListener references in
-      // https://github.com/joyent/node/blob/master/lib/http.js
-      //
-      // Catch socket errors
-      //socket.on('error', proxyError);
-
-      //
       // Remove data listener now that the 'handshake' is complete
       //
       revSocket.removeListener('data', handshake);
@@ -743,14 +727,6 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, head, buffer)
   // Handle 'error' events from the `reverseProxy`.
   //
   reverseProxy.on('error', proxyError);
-  //
-  // NOT needed as node.js re-emits the socket errors as ClientRequest 'error'
-  // Look for socketErrorListener references in
-  // https://github.com/joyent/node/blob/master/lib/http.js
-  //
-  // reverseProxy.once('socket', function (socket) {
-  //   socket.once('error', proxyError);
-  // });
 
   //
   // Handle 'error' events from the `req` (e.g. `Parse Error`).


### PR DESCRIPTION
For this issue I just commented instead of deleting the unneeded code because I only tried the normal http parts, not the web sockets but I believe that 99,9% is correct.

After some research this part is causing the problem:

``` javascript
reverseProxy.once('socket', function (socket) {
  socket.once('error', proxyError);
});
```

This is not needed as node.js' `ClientRequest` object (here the `reverseProxy`) attaches a listener to the socket 'error'

``` javascript
socket.on('error', socketErrorListener);
```

The `socketErrorListener` just re-emits the error from the `ClientRequest` object.

Look in https://github.com/joyent/node/blob/master/lib/http.js for the `socketErrorListener` references.
