### PR TITLE
Misleading documentation for Websockets via .createServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,25 @@ httpProxy.createServer(
 ## Proxying WebSockets
 Websockets are handled automatically when using `httpProxy.createServer()`, however, if you supply a callback inside the createServer call, you will need to handle the 'upgrade' proxy event yourself. Here's how:
 
+```js
+
+var options = {
+    ....
+};
+
+var server = httpProxy.createServer(
+    callback/middleware, 
+    options
+);
+
+server.listen(port, function() { ... });
+server.on('upgrade', function(req, socket, head) {
+    server.proxy.proxyWebSocketRequest(req, socket, head);
+});
+```
+
+If you would rather not use createServer call, and create the server that proxies yourself, see below:
+
 ``` js
 var http = require('http'),
     httpProxy = require('http-proxy');


### PR DESCRIPTION
It's said its handled automatically, however from my experience this isn't the whole story, and to save someone else a headache this should be remedied in the docs.

Just some background I had a connect middleware for no-www, and options..

```
var options = {
    hostnameOnly: true,
    router: {
        'api.[snip]': '127.0.0.1:3001',
        '[snip]': '127.0.0.1:3000'
    }
};

var server = httpProxy.createServer(
    nowww(false),
    options
);

server.listen(80, function() {
  console.log('proxy up');
});
```

The websockets connections aren't made automatically because I was using middleware, so you need to add..

```
server.on('upgrade', function(req, socket, head) {
    server.proxy.proxyWebSocketRequest(req, socket, head);
});
```

This should just be documented somewhere is all. It would have saved me the hour of "hmm, why is this falling back to xhr-polling?" time and source-reading lines to see the "magic"

```
if (!callback) {
  proxy.proxyWebSocketRequest(req, socket, head);
}
```

But, more than willing to give up that hour for the total amount of time you've saved me :+1: 
