### PR TITLE
Fixed a bug that generates an unexpected TypeError

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -268,7 +268,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
       delete response.headers['transfer-encoding'];
     }
 
-    if ((response.statusCode === 301) || (response.statusCode === 302)
+    if ((response.statusCode === 301 || response.statusCode === 302)
       && typeof response.headers.location !== 'undefined') {
       location = url.parse(response.headers.location);
       if (location.host === req.headers.host) {


### PR DESCRIPTION
This pull request fixes a bug that generates the following exception:

```
TypeError: Parameter 'url' must be a string, not undefined
at Object.urlParse [as parse] (url.js:96:11)
at ClientRequest.<anonymous> (/usr/lib/node_modules/test/node_modules/http-proxy/lib/node-http-proxy/http-proxy.js:273:22)
at ClientRequest.g (events.js:192:14)
at ClientRequest.EventEmitter.emit (events.js:96:17)
at HTTPParser.parserOnIncomingClient [as onIncoming] (http.js:1569:7)
at HTTPParser.parserOnHeadersComplete [as onHeadersComplete] (http.js:111:23)
at Socket.socketOnData [as ondata] (http.js:1472:20)
at TCP.onread (net.js:404:27)
```
