### PR TITLE
Change the emitter of the `proxyResponse` event

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -318,7 +318,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     });
 
     // Allow observer to modify headers or abort response
-    try { req.emit('proxyResponse', req, res, response) }
+    try { self.emit('proxyResponse', req, res, response) }
     catch (ex) {
       errState = true;
       return;

--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -116,6 +116,7 @@ RoutingProxy.prototype.add = function (options) {
     'start',
     'forward',
     'end',
+    'proxyResponse',
     'websocket:start',
     'websocket:end',
     'websocket:incoming',


### PR DESCRIPTION
This is a minor breaking change. I'm inclined to make this `0.10.0`. It was always my intention to have the event emitted on the `HttpProxy` or `RoutingProxy` instance, but I missed the edit in the PR.
