### PR TITLE
Enable passing through the target path to the pathnameOnly proxy

### DIFF
--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -222,8 +222,14 @@ ProxyTable.prototype.getProxyLocation = function (req) {
       //
       // for the route "/wiki" : "127.0.0.1:8020"
       //
+      // Given the route "/wiki" : "localhost:8080/api/"
+      // And the request /wiki/heartbeat
+      // reroute it to localhost:8080/api/heartbeat"
       if (target.match(route.source.regexp)) {
-        req.url = url.format(target.replace(route.source.regexp, ''));
+        var path = target.replace(/^\//, '').replace(route.source.regexp, '');
+        var dest = url.format(route.target.url);
+        req.url = url.resolve(dest, path);
+
         return {
           protocol: route.target.url.protocol.replace(':', ''),
           host: route.target.url.hostname,


### PR DESCRIPTION
This allows you to specify what the target path should be passed just the hostname.
