### PR TITLE
Fixed redirection on proxy when changeOrigin enable

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -286,7 +286,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     // 2. redirect to the same target without changeOrigin
     // 3. redirect to the different target with changeOrigin
     // 4. redirect to the different target without changeOrigin
-    var sameHost, samePort, sameProto;
+    var oriReqUrl, sameHost, samePort, sameProto;
     
     function isLocalhost(host){
       return ((host === 'localhost') || (host === '127.0.0.1') || (host === '0:0:0:0:0:0:0:1'));
@@ -294,20 +294,27 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
       
     if ((response.statusCode === 301 || response.statusCode === 302)
       && typeof response.headers.location !== 'undefined') {
-      location = url.parse(response.headers.location, true, true);
-            
+      location  = url.parse(response.headers.location, true, true);
+      oriReqUrl = url.parse((self.source.https ? 'https://':'http://')+self.oriReqHost, true, true);
+      
+      // handle default port
+      location.port  = location.port || ((location.protocol === 'https:') ? 443 : 80);
+      oriReqUrl.port = oriReqUrl.port || ((oriReqUrl.protocol === 'https:') ? 443 : 80);
+                  
       sameHost  = self.changeOrigin ?  
                   ((location.hostname === self.target.host) || (isLocalhost(location.hostname) && isLocalhost(self.target.host))) :
-                  (location.host === self.oriReqHost);
+                  ((location.hostname === oriReqUrl.hostname) || (isLocalhost(location.hostname) && isLocalhost(oriReqUrl.hostname)));
                   
       samePort  = self.changeOrigin ? 
                   (location.port === self.target.port) :
-                  (location.host === self.oriReqHost);
+                  (location.port === oriReqUrl.port);
                   
-      sameProto = (location.protocol === (self.target.https ? 'https:':'http:'));
+      sameProto = self.changeOrigin ?
+                 (location.protocol === (self.target.https ? 'https:':'http:')) :
+                 (location.protocol === (self.source.https ? 'https:':'http:'));
       
       if (sameHost && samePort && sameProto) {
-        response.headers.location = (self.source.https ? 'https://' : 'http://') + self.oriReqHost + location.path;
+        response.headers.location = (self.source.https ? 'https://' : 'http://') + oriReqUrl.host + location.path;
       }
       
       // TBD... case 3&4


### PR DESCRIPTION
Redirection has four cases:
1. redirect to the same target with changeOrigin
2. redirect to the same target without changeOrigin
3. redirect to the different target with changeOrigin
4. redirect to the different target without changeOrigin

the existing code can handle case 2, the fix is for case 1. case 3 and case 4 need to handle proxy response event to add proxy entry by user logic. 
