### PR TITLE
To be congruent with other popular http clients the port should be stripped from the 'Host' field when the port is 80. 

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -237,7 +237,8 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   // don't revert this without documenting it!
   //
   if (this.changeOrigin) {
-    outgoing.headers.host = this.target.host + ':' + this.target.port;
+		var port = (this.target.port-80==0?"":":"+this.target.port);
+    outgoing.headers.host = this.target.host + port;
   }
   
   //


### PR DESCRIPTION
Hi,

So we encountered an interesting problem today, less so a bug with node-http-proxy but more of a incongruent behavior from when compared against other browsers and client's we've tested. 

When working with cloudfoundry.com we found that their proxy did not consider a request to port 80 the same if the port was explicitly specified in the 'Host' header field.

So a request to http://foo.cloudfoundry.com:80/ and http://foo.cloudfoundry.com/ behaved differently. We narrowed it down to the difference in the Host field. The changeOrign logic  included the port when crafting the 'Host' header regardless of the port number. 
- http://foo.cloudfoundry.com:80/ has a Host header of "Host: foo.cloudfoundry.com:80"
- http://foo.cloudfoundry.com/ has a Host header of "Host: foo.cloudfoundry.com"

No big deal right? Well so everyone else strips port 80 because it is the default :(
- Curl strips port 80 from the Host header
- wget strips port 80 from the Host header
- Safari strips port 80 from the Host header
- Firefox strips port 80 from the Host header
- Chrome strips port 80 from the Host header

You can test the behavior using "http://helloworld-ng.cloudify.com:80/" and "http://helloworld-ng.cloudify.com/" - notice that both URLs work the same in all of the above listed browsers

In curl we can see the failure case

``` shell
$ curl http://helloworld-ng.cloudfoundry.com:80/ -H "Host: helloworld-ng.cloudfoundry.com:80"
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
$ curl http://helloworld-ng.cloudfoundry.com:80/ -H "Host: helloworld-ng.cloudfoundry.com"
Hello from Cloud Foundry
```

(We've asked cloudfoundry to fix this issue, but to be clear the behavior in node-http-proxy is incongruent with every other client and browser we've tested) 

So then the question becomes - should node-http-proxy do the same? Sadly it seems like this shouldn't be an issue but it is an unexpected behavior and no one else does it - hence why I think node-http-proxy should strip port 80 from the Host field if it is specified. 
