### PR TITLE
Send path in req.path and not the url

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -228,7 +228,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   outgoing.socketPath = this.target.socketPath;
   outgoing.agent      = this.target.agent;
   outgoing.method     = req.method;
-  outgoing.path       = req.url;
+  outgoing.path       = url.parse(req.url).path;
   outgoing.headers    = req.headers;
 
   //


### PR DESCRIPTION
According to http://nodejs.org/api/http.html#http_http_request_options_callback and http://nodejs.org/api/https.html#https_https_request_options_callback

Instead of pass the full url as path, the url is parsed and the path extracted.

Without this change, it's not possible to access to several pages on dailymotion.
