### PR TITLE
Pass default certs to SNICallback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,10 @@ var options = {
   https: {
     SNICallback: function (hostname) {
       return certs[hostname];
-    }
+    },
+    cert: myCert,
+    key: myKey,
+    ca: [myCa]
   },
   hostnameOnly: true,
   router: {


### PR DESCRIPTION
Using only SNICallback to create a HTTPS / TLS server is bad. It means all non SNI clients can't do anything because there are no certs.

in v0.10 of node TLS server was updated to throw if you forgot to supply certs.

Which means that every HTTPS server needs to supply certs as a fallback for when SNI is not available.
- closes #399
