### PR TITLE
determine x-forwarded-port from host header

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -149,11 +149,11 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     }
 
     if (req.headers['x-forwarded-port']) {
-      var portToAppend = "," + req.connection.remotePort || req.socket.remotePort;
+      var portToAppend = "," + getPortFromHostHeader(req);
       req.headers['x-forwarded-port'] += portToAppend;
     }
     else {
-      req.headers['x-forwarded-port'] = req.connection.remotePort || req.socket.remotePort;
+      req.headers['x-forwarded-port'] = getPortFromHostHeader(req);
     }
 
     if (req.headers['x-forwarded-proto']) {
@@ -480,11 +480,11 @@ HttpProxy.prototype.proxyWebSocketRequest = function (req, socket, upgradeHead, 
     }
 
     if (req.headers['x-forwarded-port']) {
-      var portToAppend = "," + req.connection.remotePort || socket.remotePort;
+      var portToAppend = "," + getPortFromHostHeader(req);
       req.headers['x-forwarded-port'] += portToAppend;
     }
     else {
-      req.headers['x-forwarded-port'] = req.connection.remotePort || socket.remotePort;
+      req.headers['x-forwarded-port'] = getPortFromHostHeader(req);
     }
 
     if (req.headers['x-forwarded-proto']) {
@@ -946,6 +946,17 @@ HttpProxy.prototype._forwardRequest = function (req) {
     forwardProxy.end();
   });
 };
+
+function getPortFromHostHeader(req) {
+  var portMatch = req.headers.host.match(/:(\d+)$/);
+
+  if(portMatch) {
+    return parseInt(portMatch[1]);
+  }
+  else {
+    return getProto(req) === 'https' ? 443 : 80;
+  }
+}
 
 function getProto(req) {
   return req.isSpdy ? 'https' : (req.connection.pair ? 'https' : 'http');


### PR DESCRIPTION
`req.remotePort` returns the ephemeral port, which is not useful.
node v0.10.0 added `req.localPort` which returns what we want, but
we want to maintain backwards compatibility. Fixes #341 & #227
