### PR TITLE
Added support for the socketPath option in the routing-proxy.

### DIFF
--- a/lib/node-http-proxy.js
+++ b/lib/node-http-proxy.js
@@ -342,8 +342,8 @@ exports.stack = function stack (middlewares, proxy) {
 // and sets the `maxSockets` property appropriately.
 //
 exports._getAgent = function _getAgent (options) {
-  if (!options || !options.host) {
-    throw new Error('`options.host` is required to create an Agent.');
+  if (!options || (!options.host && !options.socketPath)) {
+    throw new Error('`options.host` or `options.socketPath` are required to create an Agent.');
   }
 
   if (!options.port) {

--- a/lib/node-http-proxy/routing-proxy.js
+++ b/lib/node-http-proxy/routing-proxy.js
@@ -308,13 +308,19 @@ RoutingProxy.prototype.removeHost = function (host) {
 // combination contained within.
 //
 RoutingProxy.prototype._getKey = function (options) {
-  if (!options || ((!options.host || !options.port)
-    && (!options.target || !options.target.host || !options.target.port))) {
-    throw new Error('options.host and options.port or options.target are required.');
+  if (!options)
+    throw new Error("Missing options.");
+    
+  if ((options.host && options.port) || (options.target && (options.target.host && options.target.port))) {
+    return [
+      options.host || options.target.host,
+      options.port || options.target.port
+    ].join(':');
   }
-
-  return [
-    options.host || options.target.host,
-    options.port || options.target.port
-  ].join(':');
+  
+  if (options.socketPath || (options.target && options.target.socketPath)) {
+    return options.socketPath || options.target.socketPath
+  }
+  
+  throw new Error("options.socketPath or options.host and options.port or options.target are required.")
 };


### PR DESCRIPTION
The _getKey method of the RoutingProxy would throw an error if a host/port pair wasn't provided in the options of the proxyRequest call.  It will now check to see if the socketPath option was provided as well.

Additionally the _getAgent method would error if a host wasn't provided, this now checks for socketPath as well.
