### PR TITLE
Added a preservePathForTarget option for Table Proxy routing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,20 @@ var options = {
 ```
 
 This comes in handy if you are running separate services or applications on separate paths.  Note, using this option disables routing by hostname entirely.
+When using pathnameOnly option any request to yourdomain/accounts/login reaches the destination without the full path. IE a POST request to localhost:3000/accounts/login reaches the destination as a POST to localhost:8001, no path is included. This same behavior persists if the destination includes the full path.
+Adding `preservePathForTarget` as an option will make your proxy bypass the behavior of omitting the path from the the target.
 
+``` js
+var options = {
+  pathnameOnly: true,
+  preservePathForTarget: true,  
+  router: {
+    '/wiki': '127.0.0.1:8001',
+    '/blog': '127.0.0.1:8002',
+    '/api':  '127.0.0.1:8003'
+  }
+}
+```
 
 ### Proxy requests with an additional forward proxy
 Sometimes in addition to a reverse proxy, you may want your front-facing server to forward traffic to another location. For example, if you wanted to load test your staging environment. This is possible when using node-http-proxy using similar JSON-based configuration to a proxy table: 

--- a/lib/node-http-proxy/proxy-table.js
+++ b/lib/node-http-proxy/proxy-table.js
@@ -46,6 +46,7 @@ var ProxyTable = exports.ProxyTable = function (options) {
   this.target       = options.target || {};
   this.pathnameOnly = options.pathnameOnly === true;
   this.hostnameOnly = options.hostnameOnly === true;
+  this.preservePathForTarget = options.preservePathForTarget === true;  
 
   if (typeof options.router === 'object') {
     //
@@ -223,7 +224,7 @@ ProxyTable.prototype.getProxyLocation = function (req) {
       // for the route "/wiki" : "127.0.0.1:8020"
       //
       if (target.match(route.source.regexp)) {
-        req.url = url.format(target.replace(route.source.regexp, ''));
+        req.url = (this.preservePathForTarget === true) ? target : url.format(target.replace(route.source.regexp, ''));
         return {
           protocol: route.target.url.protocol.replace(':', ''),
           host: route.target.url.hostname,


### PR DESCRIPTION
Refers to this issue:
https://github.com/nodejitsu/node-http-proxy/issues/386
