### PR TITLE
Fix for #458. Host header may cause some sites not to be proxyable with changeOrigin enabled

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -237,7 +237,14 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
   // don't revert this without documenting it!
   //
   if (this.changeOrigin) {
-    outgoing.headers.host = this.target.host + ':' + this.target.port;
+    outgoing.headers.host = this.target.host;
+    // Only add port information to the header if not default port
+    // for this protocol. 
+    // See https://github.com/nodejitsu/node-http-proxy/issues/458
+    if (this.target.port !== 443 && this.target.https ||
+        this.target.port !== 80 && !this.target.https) {
+      outgoing.headers.host += ':' + this.target.port;
+    }
   }
 
   //


### PR DESCRIPTION
[RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) Section 14.23 specifies that the port argument in the Host header is optional if connecting to default port (80 on HTTP f.e.). At the moment we always add the port, but I've encountered a website (10 mio pageviews a day) running IIS 7 that doesn't accept this host header and wants one without the port specified. See http://www.funda.nl. At the moment node-http-proxy doesn't work with this site if changeOrigin is enabled. Chrome f.e. doesn't add the port if doing a request for HTTP on port 80.

I saw only integration tests, no unit tests who cover this code, that's why there aren't any attached.

/cc @nathan7 
