### PR TITLE
Added error handling example

### DIFF
--- a/examples/error-handling.js
+++ b/examples/error-handling.js
@@ -1,0 +1,26 @@
+var caronte = require('../index');
+/*
+ * Create your proxy server
+ */
+var proxyServer = caronte.createProxyServer({target:'http://localhost:30404', ws:true});
+
+// Register an error handler for web requests
+proxyServer.ee.on("caronte:outgoing:web:error", function(err, req, res){
+	res.writeHead(502);
+	res.end("There was an error proxying your request");
+});
+
+// Register an error handler for web-socket requests
+proxyServer.ee.on("caronte:outgoing:ws:error", function(err, req, socket, head){
+	socket.close();
+});
+
+// You may also use a wild card 
+proxyServer.ee.on("*:*:*:error", function(err, req){
+	console.log("The error event '" + this.event + "' happened errno: " + err.errno);
+});
+
+
+console.log("Proxy server is listening on port 8000");
+proxyServer.listen(8000);
+


### PR DESCRIPTION
@yawnt @jcrugzz, the reason that your wildcard error handler `ee.on('*:error', function (err) {}` does not get picked up is because it does not match the event emitted. you could use `ee.on('*:*:*:error', function (err) {}`

I do agree that the number of namespaces does seem a bit much. perhaps `ws:error` and `web:error` would be sufficient. 

Issues #462 #470 
