### PR TITLE
Emit http-proxy:outgoing:ws:error for errors after the upgrade header.

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -106,7 +106,7 @@ var passes = exports;
       common.setupOutgoing(options.ssl || {}, options, req)
     );
     // Error Handler
-    proxyReq.on('error', function(err){
+    var onProxyError = function(err){
       var ev   = 'http-proxy:outgoing:ws:';
       // If no error listeners, so throw the error.
       if (!options.ee.listeners(ev + 'error').length){
@@ -114,10 +114,17 @@ var passes = exports;
       }
       // Also emit the error events
       options.ee.emit(ev + 'error', err, req, socket, head);
-    });
+    };
+
+    proxyReq.on('error', onProxyError);
 
     proxyReq.on('upgrade', function(proxyRes, proxySocket, proxyHead) {
       common.setupSocket(proxySocket);
+
+      // http client removes the error handler from proxySocket (which
+      // redirected 'error' events from proxySocket to proxyReq) before emitting
+      // 'upgrade'. So we need to ask for it again.
+      proxySocket.on('error', onProxyError);
 
       if (proxyHead && proxyHead.length) proxySocket.unshift(proxyHead);
 


### PR DESCRIPTION
The Node http client (at least in 0.10.x) removes the socket error handler
(which forwards errors from socket to request) before invoking 'upgrade'. So we
need to put our error handler back on it if we don't want errors (eg
ECONNRESET/EPIPE) talking to the server to throw.

See https://gist.github.com/glasser/6893545 for an example script showing why this is necessary.
