### PR TITLE
attempting to fix links to 2 source locations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ proxies and load balancers.
 ### Core Concept
 
 A new proxy is created by calling `createProxyServer` and passing
-an `options` object as argument ([valid properties are available here](tree/master/lib/http-proxy.js#L26-L39)) 
+an `options` object as argument ([valid properties are available here](lib/http-proxy.js#L26-L39)) 
 
 ```javascript
 var httpProxy = require('http-proxy');
@@ -44,7 +44,7 @@ require('http').createServer(function(req, res) {
 });
 ```
 
-When a request is proxied it follows two different pipelines ([available here](tree/master/lib/http-proxy/passes))
+When a request is proxied it follows two different pipelines ([available here](lib/http-proxy/passes))
 which apply transformations to both the `req` and `res` object. 
 The first pipeline (ingoing) is responsible for the creation and manipulation of the stream that connects your client to the target.
 The second pipeline (outgoing) is responsible for the creation and manipulation of the stream that, from your target, returns data 


### PR DESCRIPTION
Current link for 'valid properties are available here' goes to url:

https://github.com/nodejitsu/node-http-proxy/blob/caronte/tree/master/lib/http-proxy.js#L26-L39

The url works fine if 'tree/master/' is removed, so this is trying to remove that part of the relative path.

The same removal of 'tree/master/' is being made for the 'available here' link that is preceded by "When a request is proxied it follows two different pipelines" since it suffers the same issue.

The edited README.md has both links working in my fork with this edit applied.
