### PR TITLE
bugfix(res.statusCode) correct statusCode to res from response

### DIFF
--- a/lib/node-http-proxy/http-proxy.js
+++ b/lib/node-http-proxy/http-proxy.js
@@ -329,6 +329,7 @@ HttpProxy.prototype.proxyRequest = function (req, res, buffer) {
     Object.keys(response.headers).forEach(function (key) {
       res.setHeader(key, response.headers[key]);
     });
+    res.statusCode = response.statusCode;
     res.writeHead(response.statusCode);
 
     function ondata(chunk) {


### PR DESCRIPTION
in my project, my backend server give me a 302, but proxy show me a 200.
i find it didnot work just call res.writeHead(response.statusCode);
 and need set res.statusCode.
