### PR TITLE
[fix] add `type` to before and after to grab correct `passes`, fixes #537

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -117,23 +117,33 @@ ProxyServer.prototype.listen = function(port) {
   return this;
 };
 
-ProxyServer.prototype.before = function(passName, callback) {
-  var i = false;
-  this.passes.forEach(function(v, idx) {
+ProxyServer.prototype.before = function(type, passName, callback) {
+  if (type !== 'ws' || type !== 'web') {
+    throw new Error('type must be `web` or `ws`');
+  }
+  var passes = (type === 'ws') ? this.wsPasses : this.webPasses,
+      i = false;
+
+  passes.forEach(function(v, idx) {
     if(v.name === passName) i = idx;
   })
 
   if(!i) throw new Error('No such pass');
 
-  this.passes.splice(i, 0, callback);
+  passes.splice(i, 0, callback);
 };
-ProxyServer.prototype.after = function(passName, callback) {
-  var i = false;
-  this.passes.forEach(function(v, idx) {
+ProxyServer.prototype.after = function(type, passName, callback) {
+  if (type !== 'ws' || type !== 'web') {
+    throw new Error('type must be `web` or `ws`');
+  }
+  var passes = (type === 'ws') ? this.wsPasses : this.webPasses,
+      i = false;
+
+  passes.forEach(function(v, idx) {
     if(v.name === passName) i = idx;
   })
 
   if(!i) throw new Error('No such pass');
 
-  this.passes.splice(i++, 0, callback);
+  passes.splice(i++, 0, callback);
 };


### PR DESCRIPTION
@cronopio we could probably use some tests for adding functions before/after any of the passes. 

cc @yawnt
