### PR TITLE
Fix for Issue#543 (name-based virtual host target)

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -34,6 +34,9 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
     function(e) { outgoing[e] = req[e]; }
   );
 
+  if (options[forward || 'target'].host)
+    outgoing.headers.host = options[forward || 'target'].host;
+
   if (options.headers){
     extend(outgoing.headers, options.headers);
   }


### PR DESCRIPTION
The "Host" header field that was created and sent by the proxy to the backends, was wrong, because it had been copied from the original headers that were received by the proxy.

This caused many problems; for example, when the backend web server served several websites on the same IP/port ("name-based virtual-host"), which is very common, a wrong Host header caused the request to fail or to bring the wrong site.

The patch overwrites the Host field by the real host/port of the backend.
