### PR TITLE
Only emit response if a valid server is present

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -117,7 +117,7 @@ web_o = Object.keys(web_o).map(function(pass) {
     (options.buffer || req).pipe(proxyReq);
 
     proxyReq.on('response', function(proxyRes) {
-      server.emit('proxyRes', proxyRes);
+      if(server) { server.emit('proxyRes', proxyRes); }
       for(var i=0; i < web_o.length; i++) {
        if(web_o[i](req, res, proxyRes)) { break; }
       }


### PR DESCRIPTION
When a callback is passed into .web() such as:

```
proxy.web(req, res, function (err) {
  // handle error
});
```

the `server` var is set to false and therefor can't emit the `proxyRes`.
