### PR TITLE
Fix before and after type check

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -129,7 +129,7 @@ ProxyServer.prototype.listen = function(port) {
 };
 
 ProxyServer.prototype.before = function(type, passName, callback) {
-  if (type !== 'ws' || type !== 'web') {
+  if (type !== 'ws' && type !== 'web') {
     throw new Error('type must be `web` or `ws`');
   }
   var passes = (type === 'ws') ? this.wsPasses : this.webPasses,
@@ -144,7 +144,7 @@ ProxyServer.prototype.before = function(type, passName, callback) {
   passes.splice(i, 0, callback);
 };
 ProxyServer.prototype.after = function(type, passName, callback) {
-  if (type !== 'ws' || type !== 'web') {
+  if (type !== 'ws' && type !== 'web') {
     throw new Error('type must be `web` or `ws`');
   }
   var passes = (type === 'ws') ? this.wsPasses : this.webPasses,


### PR DESCRIPTION
There was previously no way to get past these checks.
