### PR TITLE
Extend listen to enable IPv6 support.

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -111,7 +111,7 @@ function ProxyServer(options) {
 
 require('util').inherits(ProxyServer, EE3);
 
-ProxyServer.prototype.listen = function(port) {
+ProxyServer.prototype.listen = function(port, hostname) {
   var self    = this,
       closure = function(req, res) { self.web(req, res); };
 
@@ -123,7 +123,7 @@ ProxyServer.prototype.listen = function(port) {
     this._server.on('upgrade', function(req, socket, head) { self.ws(req, socket, head); });
   }
 
-  this._server.listen(port);
+  this._server.listen(port, hostname);
 
   return this;
 };


### PR DESCRIPTION
No one is assigned
http-proxy cannot listen on ipv6 ports.

IMO it should be enough to add an additional parameter 'hostname' to listen (/lib/http-proxy/index.js) and pass it to _server.listen.

See http://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback.
