### PR TITLE
Remove simple error logging

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -103,10 +103,6 @@ function ProxyServer(options) {
   this.wsPasses = Object.keys(ws).map(function(pass) {
     return ws[pass];
   });
-
-  this.on('error', function(err) {
-    console.log(err);
-  });
 }
 
 require('util').inherits(ProxyServer, EE3);


### PR DESCRIPTION
This error messaging is a bit confusing. You don't know where in your application it originated and it dumps the whole error object instead of the string message and backtrace. Since this event is exposed the user can subscribe herself to it.
