### PR TITLE
Issue #570: Use http.globalAgent as agent if no agent is explicitly specified.

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,5 +1,6 @@
 var common = exports,
     url    = require('url'),
+    http   = require('http'),
     extend = require('util')._extend;
 
 /**
@@ -42,8 +43,8 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
     outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;
   }
 
+  outgoing.agent = (options.agent == null) ? http.globalAgent : options.agent
 
-  outgoing.agent = options.agent || false;
   outgoing.path = url.parse(req.url).path;
   return outgoing;
 };


### PR DESCRIPTION
Make it so we default to [`http.globalAgent`](http://nodejs.org/api/http.html#http_http_globalagent) as the agent if no agent is explicitly specified.  This is the agent that HTTP requests use by default when no agent is specified, so this is more in keeping with the http module, and it also fixes #570.  :)

`globalAgent` was introduced way back in [node 0.5.3](http://nodejs.org/docs/v0.5.3/api/http.html#http.globalAgent), so this should be a reasonably safe change as far as compatibility goes.
