### PR TITLE
Issue #570: Disable keep-alive if no agent.

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -44,6 +44,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
 
 
   outgoing.agent = options.agent || false;
+  if(outgoing.agent === false) {
+    // Do not allow keepAlive if we have no agent, since this will cause us to leak sockets.
+    outgoing.keepAlive = false
+  }
   outgoing.path = url.parse(req.url).path;
   return outgoing;
 };


### PR DESCRIPTION
This is an alternative fix for #570 (see my other pr #572).

The idea here is that if no agent is specified, we explicitly set keepAlive to false.

If keepAlive is true, then every time we proxy a request we will create a new connection (because there is no agent managing a pool of connections), but with keepAlive set, node.js will not kill the connection after we make a request.  The connection will stay open (potentially for several minutes) eating up a file descriptor.

With keepAlive set false, node.js will close the connection for us after the request is made, cleaning up the resources immediately.  Under heavy load, this will result in far more connections than in PR #572, but may or may not result in better performance overall.  When heavy load clears, however, the connection count will drop back down immediately.

Note that, with or without this fix, connections are not being reused - all this does is clean up connections after we're done with them.  Also not that in node v0.11.11, this option is [implicitly set for us](https://github.com/joyent/node/blob/b46e77421581ea358e221a8a843d057c747f7e90/lib/_http_agent.js#L293) when node [assigns us an agent](https://github.com/joyent/node/blob/b46e77421581ea358e221a8a843d057c747f7e90/lib/_http_agent.js#L297).
