### PR TITLE
Add Repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name"           : "http-proxy",
   "version"        : "1.0.2",
-  "repository" : "https://github.com/nodejitsu/node-http-proxy.git",
+  
+  "repository"     : {
+    "type"              : "git",
+    "url"               : "https://github.com/nodejitsu/node-http-proxy.git"
+  },
+  
   "description"    : "HTTP proxying for the masses",
   "author": "Nodejitsu Inc. <info@nodejitsu.com>",
   "maintainers"    : [


### PR DESCRIPTION
Seeing "npm WARN package.json http-proxy@1.0.2 No repository field." makes me anxious :anguished: 
This PR adds a repo field to the package.json, for others who feel the same.
