### PR TITLE
Add option for attaching outgoing headers, extraHeaders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ If you are using the `proxyServer.listen` method, the following options are also
  *  **ssl**: object to be passed to https.createServer()
  *  **ws**: true/false, if you want to proxy websockets
  *  **xfwd**: true/false, adds x-forward headers
-
+ *  **extraHeaders**: an object that will attach extra headers (e.g. CORS) onto responses
 
 ### Test
 

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -119,7 +119,7 @@ web_o = Object.keys(web_o).map(function(pass) {
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes); }
       for(var i=0; i < web_o.length; i++) {
-       if(web_o[i](req, res, proxyRes)) { break; }
+       if(web_o[i](req, res, proxyRes, options)) { break; }
       }
 
       proxyRes.pipe(res);

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -35,7 +35,7 @@ var passes = exports;
    *
    * @api private
    */
-  function setConnection(req, res, proxyRes) {
+  function setConnection(req, res, proxyRes, options) {
     if (req.httpVersion === '1.0') {
       proxyRes.headers.connection = req.headers.connection || 'close';
     } else if (!proxyRes.headers.connection) {
@@ -57,6 +57,22 @@ var passes = exports;
     Object.keys(proxyRes.headers).forEach(function(key) {
       res.setHeader(key, proxyRes.headers[key]);
     });
+  },
+
+  /**
+   * Add headers from options.extraHeaders to response
+   *
+   * @param {ClientRequest} Req Request object
+   * @param {IncomingMessage} Res Response object
+   * @param {proxyResponse} Res Response object from the proxy request
+   * @param {Object} options Object with options in it
+   */
+  function attachExtraHeaders(req, res, proxyRes, options) {
+    if (options.extraHeaders != null) {
+      Object.keys(options.extraHeaders).forEach(function(header){
+        res.setHeader(header, options.extraHeaders[header]);
+      });
+    }
   },
 
   /**

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -86,6 +86,27 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
     expect(res.headers.how).to.eql('are you?');
   });
 
+  describe('#attachExtraHeaders', function() {
+    var proxyRes = {
+      headers: {
+        hey: 'hello',
+        how: 'are you?'
+      }
+    };
+
+    var res = {
+      setHeader: function(k, v) {
+        this.headers[k] = v;
+      },
+      headers: {}
+    };
+
+    httpProxy.attachExtraHeaders({}, res, proxyRes, { extraHeaders: { billy: 'sally' }});
+
+    expect(res.headers.hey).to.not.exist;
+    expect(res.headers.how).to.not.exist;
+    expect(res.headers.billy).to.eql('sally');
+  });
 
   describe('#removeChunked', function() {
     var proxyRes = {


### PR DESCRIPTION
This also required adjusting web-incoming to pass the options object to the web-outgoing passes.  One thing I noticed is that web-outgoing doesn't appear to be exposed to anyone that wants mutate it externally.

I think extensions of this nature would be better done via some well-defined API that allows me to mutate the passes on the proxy object.  But, as it stands that doesn't exist and is too much for me to just guess at what would be acceptable and try to fix.
