### PR TITLE
Add support for localAddress

### DIFF
--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -42,6 +42,7 @@ module.exports.createProxyServer = module.exports.createServer = function create
    *    ws     : <true/false, if you want to proxy websockets>
    *    xfwd   : <true/false, adds x-forward headers>
    *    secure : <true/false, verify SSL certificate>
+   *    localAddress : <Local interface string to bind for outgoing connections>
    *  }
    *
    *  NOTE: `options.ws` and `options.ssl` are optional.

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -45,6 +45,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
 
   outgoing.agent = options.agent || false;
   outgoing.path = url.parse(req.url).path;
+  outgoing.localAddress = options.localAddress;
   return outgoing;
 };
 

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -15,6 +15,7 @@ describe('lib/http-proxy/common.js', function () {
           port      : 'you',
         },
         headers: {'fizz': 'bang', 'overwritten':true},
+        localAddress: 'local.address',
       },
       {
         method    : 'i',
@@ -34,6 +35,7 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.headers.pro).to.eql('xy');
       expect(outgoing.headers.fizz).to.eql('bang');
       expect(outgoing.headers.overwritten).to.eql(true);
+      expect(outgoing.localAddress).to.eql('local.address');
     });
 
     it('should set the agent to false if none is given', function () {


### PR DESCRIPTION
When we make outgoing requests, we may want to bind to a specific local
address. This change allows the localAddress property to be specified
via the options object.
