### PR TITLE
Pass HTTPS client parameters.

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -26,7 +26,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   outgoing.port = options[forward || 'target'].port ||
                   (~['https:', 'wss:'].indexOf(options[forward || 'target'].protocol) ? 443 : 80);
 
-  ['host', 'hostname', 'socketPath'].forEach(
+  ['host', 'hostname', 'socketPath', 'pfx', 'key', 'passphrase', 'cert', 'ca', 'ciphers', 'secureProtocol'].forEach(
     function(e) { outgoing[e] = options[forward || 'target'][e]; }
   );
 

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -73,6 +73,39 @@ describe('lib/http-proxy/common.js', function () {
 
       expect(outgoing.port).to.eql(443);
     });
+
+    it('should pass through https client parameters', function () {
+      var outgoing = {};
+      common.setupOutgoing(outgoing,
+      {
+        agent     : '?',
+        target: {
+          host      : 'how',
+          hostname  : 'are',
+          socketPath: 'you',
+          protocol: 'https:',
+          pfx: 'my-pfx',
+          key: 'my-key',
+          passphrase: 'my-passphrase',
+          cert: 'my-cert',
+          ca: 'my-ca',
+          ciphers: 'my-ciphers',
+          secureProtocol: 'my-secure-protocol'
+        }
+      },
+      {
+        method    : 'i',
+        url      : 'am'
+      });
+
+      expect(outgoing.pfx).eql('my-pfx');
+      expect(outgoing.key).eql('my-key');
+      expect(outgoing.passphrase).eql('my-passphrase');
+      expect(outgoing.cert).eql('my-cert');
+      expect(outgoing.ca).eql('my-ca');
+      expect(outgoing.ciphers).eql('my-ciphers');
+      expect(outgoing.secureProtocol).eql('my-secure-protocol');
+    });
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
For my application I need fine-grained control over the ciphers used when establishing the TLS sockets underlying the outgoing HTTPS connection. This functionality is supported by the HTTPS client using the `ciphers` parameter:
http://nodejs.org/api/https.html#https_https_request_options_callback
However, I couldn't find a way to use the parameter in the backend of a proxy, hence this pull request.

While I was in there I thought I'd add all of the other optional HTTPS parameters, so this pull request also passes `pfx`, `key`, `passphrase`, `cert`, `ca` and `secureProtocol`.
