### PR TITLE
Fix for #591

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -75,7 +75,7 @@ common.setupSocket = function(socket) {
 };
 
 common.getPort = function(req) {
-  var res = req.headers.host.match(/:(\d+)/);
+  var res = req.headers.host ? req.headers.host.match(/:(\d+)/) : "";
   return res ? 
     res[1] :
     req.connection.pair ? '443' : '80' ; 


### PR DESCRIPTION
Fix for proxy crash if `HOST` header is not defined bug https://github.com/nodejitsu/node-http-proxy/issues/591.
