### PR TITLE
Add pathname of target (or forward) URL

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -56,9 +56,14 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   }
 
   //
+  // Add proxy path
+  //
+  outgoing.path = options.target && options.target.path ? options.target.path : "";
+  
+  //
   // Remark: Can we somehow not use url.parse as a perf optimization?
   //
-  outgoing.path = !options.toProxy
+  outgoing.path += !options.toProxy
     ? url.parse(req.url).path
     : req.url;
 


### PR DESCRIPTION
With this change, you can have a path following the target address and port, such as:

  {target: 'http://localhost:80/some/path/'}
