### PR TITLE
Added client's req object to `proxyRes` event

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -131,7 +131,7 @@ web_o = Object.keys(web_o).map(function(pass) {
     (options.buffer || req).pipe(proxyReq);
 
     proxyReq.on('response', function(proxyRes) {
-      if(server) { server.emit('proxyRes', proxyRes); }
+      if(server) { server.emit('proxyRes', proxyRes, req); }
       for(var i=0; i < web_o.length; i++) {
        if(web_o[i](req, res, proxyRes)) { break; }
       }


### PR DESCRIPTION
The req object gives listeners of the proxyRes event access to the original client request, and thus allows accessing the session and identifying the user for whom we are doing the routing operation. Added the req object as second parameter, so it won't break existing code.
