### PR TITLE
Move timeout from the incoming socket to the outgoing one.

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -35,6 +35,22 @@ web_o = Object.keys(web_o).map(function(pass) {
   },
 
   /**
+   * Sets timeout in request socket if it was specified in options.
+   *
+   * @param {ClientRequest} Req Request object
+   * @param {IncomingMessage} Res Response object
+   * @param {Object} Options Config object passed to the proxy
+   *
+   * @api private
+   */
+
+  function timeout(req, res, options) {
+    if(options.timeout) {
+      req.socket.setTimeout(options.timeout);
+    }
+  },
+
+  /**
    * Sets `x-forwarded-*` headers if specified in config.
    *
    * @param {ClientRequest} Req Request object
@@ -93,9 +109,9 @@ web_o = Object.keys(web_o).map(function(pass) {
       common.setupOutgoing(options.ssl || {}, options, req)
     );
 
-    if(options.timeout) {
+    if(options.proxy_timeout) {
       proxyReq.on('socket', function (socket) {
-        socket.setTimeout(options.timeout);
+        socket.setTimeout(options.proxy_timeout);
         socket.on('timeout', function() {
           proxyReq.abort();
         });

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -15,6 +15,19 @@ describe('lib/http-proxy/passes/web.js', function() {
     })
   });
 
+  describe('#timeout', function() {
+    it('should set timeout on the socket', function() {
+      var done = false, stubRequest = {
+        socket: {
+          setTimeout: function(value) { done = value; }
+        }
+      }
+
+      webPasses.timeout(stubRequest, {}, { timeout: 5000});
+      expect(done).to.eql(5000);
+    });
+  });
+
   describe('#XHeaders', function () {
     var stubRequest = {
       connection: {


### PR DESCRIPTION
The issue was that when setting a timeout it was only getting set on the incoming socket, not on the outgoing http request. So the incoming request would get closed but the error handler wouldn't run, and the outgoing request would remain open.

This PR moves the timeout from the incoming socket to the outgoing one, and aborts the request on a timeout. The result is that error callbacks will run on a timeout, and that outgoing http requests won't remain open.
