### PR TITLE
Sets request host header to target host name

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -19,6 +19,23 @@ web_o = Object.keys(web_o).map(function(pass) {
 [ // <--
 
   /**
+   * Sets `host` to target host
+   *
+   * @param {ClientRequest} Req Request object
+   * @param {IncomingMessage} Res Response object
+   * @param {Object} Options Config object passed to the proxy
+   *
+   * @api private
+   */
+  
+  function fixHostHeader(req, res, options) {
+    var url = options.target || options.forward;
+    if (url) {
+      req.headers['host'] = url.host || url.hostname;
+    }
+  },
+
+  /**
    * Sets `content-length` to '0' if request is of DELETE type.
    *
    * @param {ClientRequest} Req Request object


### PR DESCRIPTION
The "Host" header field had been copied from the original headers that were received by the proxy may cause some problems.

If the backends uses hostname to distribute requests,  was wrong, because the request "Host" header points to the proxy server.
