### PR TITLE
Fixes content from the response from node.js being cut off

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -47,16 +47,20 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   outgoing.localAddress = options.localAddress;
 
   //
-  // Remark: If we are false and not upgrading, set the connection: close. This is the right thing to do
-  // as node core doesn't handle this COMPLETELY properly yet.
+  // Remark: agent string set to false can break proxies response from node
   //
-  if (!outgoing.agent) {
-    outgoing.headers = outgoing.headers || {};
-    if (typeof outgoing.headers.connection !== 'string'
-        || outgoing.headers.connection.toLowerCase() !== 'upgrade'
-       ) { outgoing.headers.connection = 'close'; }
-  }
-
+  if (outgoing.agent === false)
+    delete outgoing.agent;
+  //
+  // Remark: HTTP/1.1 spec says:
+  // The Connection general-header field allows the sender to specify options 
+  // that are desired for that particular connection and MUST NOT be 
+  // communicated by proxies over further connections.
+  // See: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+  //
+  if (outgoing.headers && outgoing.headers.connection == "close")
+    delete outgoing.headers.connection;
+  
   //
   // Remark: Can we somehow not use url.parse as a perf optimization?
   //


### PR DESCRIPTION
According to HTTP/1.1 Spec:

The Connection general-header field allows the sender to specify options that are desired for that particular connection and MUST NOT be communicated by proxies over further connections.
See: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

I noticed that when sending agent: false this would also have the same behavior. With a non-node back-end such as apache, things work fine.

I have simple test cases available if you'd like to experiment with them.
