### PR TITLE
Fix simple-balancer example

### DIFF
--- a/examples/balancer/simple-balancer.js
+++ b/examples/balancer/simple-balancer.js
@@ -58,7 +58,7 @@ http.createServer(function (req, res) {
   //
   // ...and then the server you just used becomes the last item in the list.
   //
-  addresses.push(target);
+  addresses.push(target.target);
 }).listen(8021);
 
 // Rinse; repeat; enjoy.


### PR DESCRIPTION
The balancer example will only work for the first two requests, as the `target` that is pushed back to `addresses` has the form:

``` js
{
    target: {
        host: 'ws1.0.0.0',
        port: 80
    }
}
```

when should have the form:

``` js
{
    host: 'ws1.0.0.0',
    port: 80
}
```
