### PR TITLE
Allow proxy to maintain the original target path

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,4 +1,5 @@
 var common = exports,
+    path   = require('path'),
     url    = require('url'),
     extend = require('util')._extend;
 
@@ -57,16 +58,21 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
        ) { outgoing.headers.connection = 'close'; }
   }
 
-  
+
   // the final path is target path + relative path requested by user:
-  outgoing.path = options.target.path;
+  var target = options[forward || 'target'];
+  var targetPath = target
+    ? (target.path || '')
+    : '';
 
   //
   // Remark: Can we somehow not use url.parse as a perf optimization?
   //
-  outgoing.path += !options.toProxy
+  var outgoingPath = !options.toProxy
     ? url.parse(req.url).path
     : req.url;
+
+  outgoing.path = path.join(targetPath, outgoingPath);
 
   return outgoing;
 };

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -117,6 +117,29 @@ describe('lib/http-proxy/common.js', function () {
 
       expect(outgoing.port).to.eql(443);
     });
+
+    it('should keep the original target path in the outgoing path', function(){
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {target:
+        { path: 'some-path' }
+      }, { url : 'am' });
+
+      expect(outgoing.path).to.eql('some-path/am');
+    });
+
+    it('should keep the original forward path in the outgoing path', function(){
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {
+        target: {},
+        forward: {
+          path: 'some-path'
+        }
+      }, {
+        url : 'am'
+      }, 'forward');
+
+      expect(outgoing.path).to.eql('some-path/am');
+    });
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
This completes the work started in: https://github.com/nodejitsu/node-http-proxy/pull/645
- Fixed tests
- Added a test for the path behavior
