### PR TITLE
Urgent: Fix breaking bug on url joining resulting in paths like `///path`.

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -71,9 +71,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
     ? url.parse(req.url).path
     : req.url;
 
-  outgoing.path = targetPath
-    ? targetPath + '/' + outgoingPath
-    : outgoingPath;
+  outgoing.path = common.urlJoin(targetPath, outgoingPath);
 
   return outgoing;
 };
@@ -109,4 +107,12 @@ common.getPort = function(req) {
   return res ?
     res[1] :
     req.connection.pair ? '443' : '80' ;
-}
+};
+
+// OS-agnostic join (doesn't break on URLs like path.join does on Windows)
+common.urlJoin = function() {
+  var args = Array.prototype.slice.call(arguments);
+  // Join all strings, but remove empty strings so we don't get extra slashes from 
+  // joining e.g. ['', 'am']
+  return args.filter(function(a) { return !!a; }).join('/').replace(/\/+/g, '/');
+};

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -150,6 +150,15 @@ describe('lib/http-proxy/common.js', function () {
 
       expect(outgoing.path).to.eql('hi');
     })
+
+    it('should properly join paths', function () {
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {
+        target: { path: '/forward' },
+      }, { url: '/static/path' });
+
+      expect(outgoing.path).to.eql('/forward/static/path');
+    })
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
[This commit](https://github.com/nodejitsu/node-http-proxy/commit/ed73f06ed307ad2204e565781cc3154047941a8c) can completely break production apps and this or a similar hotfix needs to be deployed ASAP.
