### PR TITLE
Fixed misleading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,13 @@ proxyServer.listen(8015);
  *  **forward**: url string to be parsed with the url module
  *  **agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)
  *  **secure**: true/false, if you want to verify the SSL Certs
+ *  **xfwd**: true/false, adds x-forward headers
+ *  **toProxy**: passes the absolute URL as the `path` (useful for proxying to proxies)
 
 If you are using the `proxyServer.listen` method, the following options are also applicable:
 
  *  **ssl**: object to be passed to https.createServer()
  *  **ws**: true/false, if you want to proxy websockets
- *  **xfwd**: true/false, adds x-forward headers
- *  **toProxy**: passes the absolute URL as the `path` (useful for proxying to proxies)
 
 ### Shutdown
 


### PR DESCRIPTION
options.xfwd definitely works fine without using the .listen method, and, AFAICT, .toProxy should as well.  Only .ssl and .ws are referenced in .listen.
