### PR TITLE
exposing proxySocket on socket to support sniffing messages coming from proxy target

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ http.createServer(function (req, res) {
 
 * `error`: The error event is emitted if the request to the target fail.
 * `proxyRes`: This event is emitted if the request to the target got a response.
+* `proxySocket`: This event is emitted once the proxy websocket was created and piped into the target websocket.
 
 ```js
 var httpProxy = require('http-proxy');
@@ -220,6 +221,13 @@ proxy.on('proxyRes', function (proxyRes, req, res) {
   console.log('RAW Response from the target', JSON.stringify(proxyRes.headers, true, 2));
 });
 
+//
+// Listen for the `proxySocket` event on `proxy`.
+//
+proxy.on('proxySocket', function (proxySocket) {
+  // listen for messages coming FROM the target here
+  proxySocket.on('data', hybiParseAndLogMessage);
+});
 ```
 
 #### Using HTTPS

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -108,6 +108,7 @@ var passes = exports;
         return i + ": " + proxyRes.headers[i];
       }).join('\r\n') + '\r\n\r\n');
       proxySocket.pipe(socket).pipe(proxySocket);
+      server.emit('proxySocket', proxySocket);
     });
 
     return proxyReq.end(); // XXX: CHECK IF THIS IS THIS CORRECT


### PR DESCRIPTION
Basically I need access to the proxySocket in order to listen to messages coming back.

I realize the implementation is a bit hacky, but it's the only way I could think of ATM. I'm open for other suggestions.

Here is an example use case taken from [chromium-remote-debugging-proxy](https://github.com/thlorenz/chromium-remote-debugging-proxy/blob/792e92a1fe3f8035dd6f78504c2d5880756ce340/index.js#L85-L89)

``` js
socket.on('data', function ondata(data) {
    if (socket.proxySocket) {
      socket.proxySocket.on('data', function ondata(data) {
        retHybi.parse(data)
      })
     socket.proxySocket = undefined;
    }
})
```

If there is an existing way to make this work, please let me know as well.
