### PR TITLE
only emit proxySocket on server if server exists

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -108,7 +108,9 @@ var passes = exports;
         return i + ": " + proxyRes.headers[i];
       }).join('\r\n') + '\r\n\r\n');
       proxySocket.pipe(socket).pipe(proxySocket);
-      server.emit('proxySocket', proxySocket);
+      if (server) {
+        server.emit('proxySocket', proxySocket);
+      }
     });
 
     return proxyReq.end(); // XXX: CHECK IF THIS IS THIS CORRECT


### PR DESCRIPTION
After upgrading to 1.5, my code started failing with:

```
TypeError: Object false has no method 'emit'
```
