### PR TITLE
close socket if upstream request fails

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -124,6 +124,7 @@ var passes = exports;
       } else {
         server.emit('error', err, req, socket);
       }
+      socket.end();
     }
   }
 

--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -280,17 +280,24 @@ describe('lib/http-proxy.js', function() {
       client.on('open', function () {
         client.send('hello there');
       });
+      
+      var count = 0;
+      function maybe_done () {
+        count += 1;
+        if (count === 2) done();
+      }
 
       client.on('error', function (err) {
         expect(err).to.be.an(Error);
         expect(err.code).to.be('ECONNRESET');
+        maybe_done();
       });
 
       proxy.on('error', function (err) {
         expect(err).to.be.an(Error);
         expect(err.code).to.be('ECONNREFUSED');
         proxyServer.close();
-        done();
+        maybe_done();
       });
     });
 


### PR DESCRIPTION
adds `socket.end()` to `on('error')` handlers for proxyReq and proxySocket

covers a case that I thought I was testing for in #708, but missed because the client `error` event simply didn't fire.
