### PR TITLE
Fix an issue with NTLM authentication

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -55,7 +55,11 @@ var passes = exports;
    */
   function writeHeaders(req, res, proxyRes) {
     Object.keys(proxyRes.headers).forEach(function(key) {
-      res.setHeader(key, proxyRes.headers[key]);
+      var v = proxyRes.headers[key]
+      if(key == 'www-authenticate'){
+        v = v.split(',');
+      }
+      res.setHeader(key, v);
     });
   },
 


### PR DESCRIPTION
NTLM authentication sends a challenge and response which translate to www-authenticate fields which are concated into a single string. When you send the response back proxied you need to split the string and send it back as an array. You will still need to create a keepalive agent to use this. So I used the library agentkeepalive like so..

To actually use this code a relevant code snippet might be:
```js

var httpProxy = require('http-proxy');
var Agent = require('agentkeepalive');

var agent =  new Agent({
  maxSockets: 100,
  keepAlive :true,
  maxFreeSockets: 10,
  keepAliveMsecs:1000,
  timeout: 60000,
  keepAliveTimeout: 30000 // free socket keepalive for 30 seconds
});
var proxy = httpProxy.createProxyServer({ target:myserver,agent:agent});
```
/*