### PR TITLE
websocket needs to respect `options.secure` too

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -39,7 +39,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
     extend(outgoing.headers, options.headers);
   }
 
-  if (options[forward || 'target'].protocol == 'https:') {
+  if (~['https:', 'wss:'].indexOf(options[forward || 'target'].protocol)) {
     outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;
   }
 


### PR DESCRIPTION
A simple change to make secured web socket connections respect `options.secure`. Before, this was throwing `[Error: Hostname/IP doesn't match certificate's altnames]`
