### PR TITLE
do not modify the query string

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -77,7 +77,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (options.changeOrigin) {
     outgoing.headers.host = outgoing.host;
   }
-  
+
   return outgoing;
 };
 
@@ -134,9 +134,24 @@ common.getPort = function(req) {
 
 common.urlJoin = function() {
   var args = Array.prototype.slice.call(arguments);
+
+  // We do not want to mess with the query string. All we want to touch is the path.
+  var lastIndex = args.length-1;
+  var last = args[lastIndex]
+  var lastSegs = last.split('?')
+  args[lastIndex] = lastSegs[0]
+
   // Join all strings, but remove empty strings so we don't get extra slashes from
   // joining e.g. ['', 'am']
-  return args.filter(function filter(a) {
-    return !!a;
-  }).join('/').replace(/\/+/g, '/');
+  var retSegs = [
+    args.filter(function filter(a) {
+      return !!a;
+    }).join('/').replace(/\/+/g, '/')
+  ];
+
+  // Only join the query string if it exists so we don't have trailing a '?'
+  // on every request
+  lastSegs[1] && retSegs.push(lastSegs[1]);
+
+  return retSegs.join('?')
 };

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -202,6 +202,15 @@ describe('lib/http-proxy/common.js', function () {
 
       expect(outgoing.path).to.eql('/forward/static/path');
     })
+
+    it('should not modify the query string', function () {
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {
+        target: { path: '/forward' },
+      }, { url: '/?foo=bar//&target=http://foobar.com/' });
+
+      expect(outgoing.path).to.eql('/forward/?foo=bar//&target=http://foobar.com/');
+    })
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
Fix the issue of multiple consecutive slashes being replaced by a single slash referenced in #703 and #710 by separating the query string from the rest of the URL in `common.urlJoin`. I tried removing trailing slashes as suggested by @yulesyu in #703 but that still caused issues if the query string ended in `//`
