### PR TITLE
copy headers instead of referencing them so they don't unexpectedly get overwritten

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -31,8 +31,8 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
     function(e) { outgoing[e] = options[forward || 'target'][e]; }
   );
 
-  outgoing.method = req.method
-  outgoing.headers = extend({},req.headers)
+  outgoing.method = req.method;
+  outgoing.headers = extend({}, req.headers);
 
   if (options.headers){
     extend(outgoing.headers, options.headers);

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -156,7 +156,7 @@ describe('lib/http-proxy/common.js', function () {
 
       expect(outgoing.method).to.eql('i');
       expect(outgoing.path).to.eql('am');
-      expect(outgoing.headers.pro).to.eql('xy')
+      expect(outgoing.headers.pro).to.eql('xy');
 
       expect(outgoing.port).to.eql(443);
     });


### PR DESCRIPTION
Currently `common.setupOutgoing` uses a reference to the original request headers, which causes `Connection` to be overwritten in some cases, and `Host` to be overwritten when `changeOrigin` is set to `true`. If you use the `proxyReq` to look at the original request and the proxy request you will find that those headers have been modified on the original request object.

I modified one test case that set the request headers to a string because using `utils._extend` on a string doesn't work. As far as I know `req.headers` will always be an object so I think what I did is fine but if there's a reason that was a string, I'll fix it so it checks the type.
