### PR TITLE
Set `Content-Length` header for OPTIONS requests

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -29,7 +29,8 @@ web_o = Object.keys(web_o).map(function(pass) {
    */
 
   function deleteLength(req, res, options) {
-    if(req.method === 'DELETE' && !req.headers['content-length']) {
+    if((req.method === 'DELETE' || req.method === 'OPTIONS')
+       && !req.headers['content-length']) {
       req.headers['content-length'] = '0';
     }
   },

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -5,14 +5,23 @@ var webPasses = require('../lib/http-proxy/passes/web-incoming'),
 
 describe('lib/http-proxy/passes/web.js', function() {
   describe('#deleteLength', function() {
-    it('should change `content-length`', function() {
+    it('should change `content-length` for DELETE requests', function() {
       var stubRequest = {
         method: 'DELETE',
         headers: {}
       };
       webPasses.deleteLength(stubRequest, {}, {});
       expect(stubRequest.headers['content-length']).to.eql('0');
-    })
+    });
+
+    it('should change `content-length` for OPTIONS requests', function() {
+      var stubRequest = {
+        method: 'OPTIONS',
+        headers: {}
+      };
+      webPasses.deleteLength(stubRequest, {}, {});
+      expect(stubRequest.headers['content-length']).to.eql('0');
+    });
   });
 
   describe('#timeout', function() {


### PR DESCRIPTION
Note also that this change was previously suggested as part of the resolution of https://github.com/nodejitsu/node-http-proxy/pull/338, but it never made it to `master`.

I'm not so happy about special-casing individual HTTP verbs like this, and I doubt the maintainers are, either. A better solution would involve disabling the default Node.js behavior described in the commit message (below). That behavior might make sense to make the `http` and `https` modules more usable, but in the setting of an HTTP proxy, fidelity is much more important.

This seems possible via [the `useChunkedEncodingByDefault` attribute](https://github.com/joyent/node/blob/cfcb1de130867197cbc9c6012b7e84e08e53d032/lib/_http_outgoing.js#L275-L280), but that is undocumented and likely unstable. I wasn't able to get it working locally, likely because [this library uses `pipe` for _all_ "incoming" requests](https://github.com/nodejitsu/node-http-proxy/blob/aba505d159a7dd46e46dd3ceb1b9565308b4d6af/lib/http-proxy/passes/web-incoming.js#L142). When piping data, the `useChunkedEncodingByDefault` flag does not seem to be honored. This probably makes sense because a streaming interface would generally emit data in chunks... so maybe special-casing HTTP verbs is the best approach, after all.

Commit message:

> Web browsers automatically issue an OPTIONS request in advance of other
> HTTP requests when the document's domain does not match the target in
> order to facilitate Cross-Origin Resource Sharing. These requests are
> forbidden from specifying a body and typically do not specify an
> (unecessary) `Length` header.
> 
> Node.js automatically adds the `Content-Encoding: chunked` header value
> to requests that do not specify a `Length` header. This makes proxied
> OPTIONS requests from web browsers invalid.
> 
> Explicitly set the `Content-Length` header of all `OPTIONS` requests to
> "0", disabling the default "chunked" encoding behavior [2].
> 
> [1] http://www.w3.org/TR/cors/
> [2] http://nodejs.org/api/http.html
