### PR TITLE
Update lib-http-proxy-common-test.js

### DIFF
--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -203,13 +203,13 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.path).to.eql('/forward/static/path');
     })
 
-    it('should not modify the query string', function () {
+    it('should not modify the query string and hash string', function () {
       var outgoing = {};
       common.setupOutgoing(outgoing, {
         target: { path: '/forward' },
-      }, { url: '/?foo=bar//&target=http://foobar.com/' });
+      }, { url: '/?foo=bar//&target=http://foobar.com/?a=1%26b=2&other=some#id12' });
 
-      expect(outgoing.path).to.eql('/forward/?foo=bar//&target=http://foobar.com/');
+      expect(outgoing.path).to.eql('/forward/?foo=bar//&target=http://foobar.com/?a=1%26b=2&other=some#id12');
     })
   });
 


### PR DESCRIPTION
Supply the last case content in the `common.setupOutgoing` function for existed many '?' in a url.

Hope you could revise it.

ref: [the previous pull request](https://github.com/nodejitsu/node-http-proxy/pull/744)
