### PR TITLE
Include port when using changeOrigin

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -74,7 +74,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   outgoing.path = common.urlJoin(targetPath, outgoingPath);
 
   if (options.changeOrigin) {
-    outgoing.headers.host = outgoing.host;
+    outgoing.headers.host = outgoing.host + ':' + outgoing.port;
   }
 
   return outgoing;


### PR DESCRIPTION
According to the HTTP spec, the port needs to be included in the host header if it's not the default port. It can be included even if it is the default port, so the easiest thing to do is always include it.
