### PR TITLE
fix "x-forwarded-proto" in node 0.12 and iojs

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -64,10 +64,11 @@ web_o = Object.keys(web_o).map(function(pass) {
   function XHeaders(req, res, options) {
     if(!options.xfwd) return;
 
+    var encrypted = req.isSpdy || req.connection.encrypted || req.connection.pair;
     var values = {
       for  : req.connection.remoteAddress || req.socket.remoteAddress,
       port : common.getPort(req),
-      proto: req.isSpdy ? 'https' : (req.connection.pair ? 'https' : 'http')
+      proto: encrypted ? 'https' : 'http'
     };
 
     ['for', 'port', 'proto'].forEach(function(header) {


### PR DESCRIPTION
The way to detect TLSSockets in node 0.12 and iojs has changed. You can
just check `socket.encrypted` now :)

Fixes #772