### PR TITLE
Fix #747

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -80,7 +80,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   // Remark: Can we somehow not use url.parse as a perf optimization?
   //
   var outgoingPath = !options.toProxy
-    ? url.parse(req.url).path
+    ? (url.parse(req.url).path || '/')
     : req.url;
 
   outgoing.path = common.urlJoin(targetPath, outgoingPath);

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -299,6 +299,17 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.ciphers).eql('my-ciphers');
       expect(outgoing.secureProtocol).eql('my-secure-protocol');
     });
+
+    // url.parse('').path => null
+    it('should not pass null as last arg to #urlJoin', function(){
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {target:
+        { path: '' }
+      }, { url : '' });
+
+      expect(outgoing.path).to.be('/');
+    });
+
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
https://github.com/nodejitsu/node-http-proxy/issues/747

If `req.url` is an empty string, `url.parse(req.url).path`  is `null` and `common.urlJoin` will raise a `TypeError`.