### PR TITLE
Fix default port detection with node 0.12.x

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -134,7 +134,20 @@ common.getPort = function(req) {
 
   return res ?
     res[1] :
-    req.connection.pair ? '443' : '80';
+    common.hasEncryptedConnection(req) ? '443' : '80';
+};
+
+/**
+ * Check if the request has an encrypted connection.
+ *
+ * @param {Request} req Incoming HTTP request.
+ *
+ * @return {Boolean} Whether the connection is encrypted or not.
+ *
+ * @api private
+ */
+common.hasEncryptedConnection = function(req) {
+  return Boolean(req.connection.encrypted || req.connection.pair);
 };
 
 /**

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -64,7 +64,7 @@ web_o = Object.keys(web_o).map(function(pass) {
   function XHeaders(req, res, options) {
     if(!options.xfwd) return;
 
-    var encrypted = req.isSpdy || req.connection.encrypted || req.connection.pair;
+    var encrypted = req.isSpdy || common.hasEncryptedConnection(req);
     var values = {
       for  : req.connection.remoteAddress || req.socket.remoteAddress,
       port : common.getPort(req),

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -57,7 +57,7 @@ var passes = exports;
     var values = {
       for  : req.connection.remoteAddress || req.socket.remoteAddress,
       port : common.getPort(req),
-      proto: req.connection.pair ? 'wss' : 'ws'
+      proto: common.hasEncryptedConnection(req) ? 'wss' : 'ws'
     };
 
     ['for', 'port', 'proto'].forEach(function(header) {

--- a/test/lib-https-proxy-test.js
+++ b/test/lib-https-proxy-test.js
@@ -35,6 +35,7 @@ describe('lib/http-proxy.js', function() {
           ssl: {
             key: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-key.pem')),
             cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-cert.pem')),
+            ciphers: 'AES128-GCM-SHA256',
           }
         }).listen(ports.proxy);
 
@@ -65,6 +66,7 @@ describe('lib/http-proxy.js', function() {
         var source = https.createServer({
           key: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-key.pem')),
           cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-cert.pem')),
+          ciphers: 'AES128-GCM-SHA256',
         }, function (req, res) {
           expect(req.method).to.eql('GET');
           expect(req.headers.host.split(':')[1]).to.eql(ports.proxy);
@@ -105,6 +107,7 @@ describe('lib/http-proxy.js', function() {
         var source = https.createServer({
           key: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-key.pem')),
           cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-cert.pem')),
+          ciphers: 'AES128-GCM-SHA256',
         }, function(req, res) {
           expect(req.method).to.eql('GET');
           expect(req.headers.host.split(':')[1]).to.eql(ports.proxy);
@@ -119,6 +122,7 @@ describe('lib/http-proxy.js', function() {
           ssl: {
             key: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-key.pem')),
             cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-cert.pem')),
+            ciphers: 'AES128-GCM-SHA256',
           },
           secure: false
         }).listen(ports.proxy);
@@ -150,6 +154,7 @@ describe('lib/http-proxy.js', function() {
         var source = https.createServer({
           key: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-key.pem')),
           cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-cert.pem')),
+          ciphers: 'AES128-GCM-SHA256',
         }).listen(ports.source);
 
         var proxy = httpProxy.createProxyServer({
@@ -191,6 +196,7 @@ describe('lib/http-proxy.js', function() {
         var ownServer = https.createServer({
           key: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-key.pem')),
           cert: fs.readFileSync(path.join(__dirname, 'fixtures', 'agent2-cert.pem')),
+          ciphers: 'AES128-GCM-SHA256',
         }, function (req, res) {
           proxy.web(req, res, {
             target: 'http://127.0.0.1:' + ports.source

--- a/test/lib-https-proxy-test.js
+++ b/test/lib-https-proxy-test.js
@@ -166,7 +166,11 @@ describe('lib/http-proxy.js', function() {
 
         proxy.on('error', function (err, req, res) {
           expect(err).to.be.an(Error);
-          expect(err.toString()).to.be('Error: DEPTH_ZERO_SELF_SIGNED_CERT')
+          if (process.versions.node.indexOf('0.12.') == 0) {
+            expect(err.toString()).to.be('Error: self signed certificate')
+          } else {
+            expect(err.toString()).to.be('Error: DEPTH_ZERO_SELF_SIGNED_CERT')
+          }
           done();
         })
 


### PR DESCRIPTION
With node 0.12.2, `common.getPort` was always returning a default port `80` even for HTTPS connections, because `req.connection.pair` is undefined on this version of node.

Here is a fix, along with some fixes for the HTTPS tests. It has been tested with node 0.10.38 and node 0.12.2 on windows.