### PR TITLE
Fixed missing documentation: #options.headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ proxyServer.listen(8015);
 *  **hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.
 *  **autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.
 *  **protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.
+ *  **headers**: object with extra headers to be added to target requests.
 
 **NOTE:**  
 `options.ws` and `options.ssl` are optional.  


### PR DESCRIPTION
Document the option: "headers", as seen in existing example:
https://github.com/nodejitsu/node-http-proxy/blob/master/examples/http/proxy-http-to-https.js

This options will add provided map of headers to requests to target.