### PR TITLE
Added installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ node-http-proxy
 websockets. It is suitable for implementing components such as
 proxies and load balancers.
 
+### Installation
+
+`npm install http-proxy --save`
+
 ### Build Status
 
 <p align="center">


### PR DESCRIPTION
Installation process may be something obvious but is better if are documented.

I am creating this PR because I tried to install it using the package name `node-http-proxy` as the readme stands, but it happens to be the wrong name.

The correct name is `http-proxy`.