### PR TITLE
Don't overwrite global options

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -46,9 +46,9 @@ function createRightProxy(type) {
         args[cntr] !== res
       ) {
         //Copy global options
-        options = extend({}, options);
+        var requestOptions = extend({}, options);
         //Overwrite with request options
-        extend(options, args[cntr]);
+        extend(requestOptions, args[cntr]);
 
         cntr--;
       }
@@ -60,11 +60,11 @@ function createRightProxy(type) {
       /* optional args parse end */
 
       ['target', 'forward'].forEach(function(e) {
-        if (typeof options[e] === 'string')
-          options[e] = parse_url(options[e]);
+        if (typeof requestOptions[e] === 'string')
+          requestOptions[e] = parse_url(requestOptions[e]);
       });
 
-      if (!options.target && !options.forward) {
+      if (!requestOptions.target && !requestOptions.forward) {
         return this.emit('error', new Error('Must provide a proper URL as target'));
       }
 
@@ -77,7 +77,7 @@ function createRightProxy(type) {
          * refer to the connection socket
          * pass(req, socket, options, head)
          */
-        if(passes[i](req, res, options, head, this, cbl)) { // passes can return a truthy value to halt the loop
+        if(passes[i](req, res, requestOptions, head, this, cbl)) { // passes can return a truthy value to halt the loop
           break;
         }
       }

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -41,15 +41,14 @@ function createRightProxy(type) {
         cntr--;
       }
 
+      //Copy global options
+      var requestOptions = extend({}, options);
       if(
         !(args[cntr] instanceof Buffer) &&
         args[cntr] !== res
       ) {
-        //Copy global options
-        var requestOptions = extend({}, options);
         //Overwrite with request options
         extend(requestOptions, args[cntr]);
-
         cntr--;
       }
 


### PR DESCRIPTION
Global options are being overwritten with every request causing per-request options to leak into the next call.
