### PR TITLE
Removed host proxy constraint

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -50,13 +50,15 @@ var redirectRegex = /^30(1|2|7|8)$/;
     if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
-     
+      var target = url.parse(options.target);
       var u = url.parse(proxyRes.headers['location']);
 
       if (options.hostRewrite) {
         u.host = options.hostRewrite;
       } else if (options.autoRewrite) {
         u.host = req.headers['host'];
+      } else if (target.host != u.host) {
+        u.host = target.host;
       }
       if (options.protocolRewrite) {
         u.protocol = options.protocolRewrite;

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -50,13 +50,8 @@ var redirectRegex = /^30(1|2|7|8)$/;
     if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
-      var target = url.parse(options.target);
+     
       var u = url.parse(proxyRes.headers['location']);
-
-      // make sure the redirected host matches the target host before rewriting
-      if (target.host != u.host) {
-        return;
-      }
 
       if (options.hostRewrite) {
         u.host = options.hostRewrite;

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -48,21 +48,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
         this.options.autoRewrite = true;
         httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
         expect(this.proxyRes.headers.location).to.eql('http://ext-manual.com/');
-      });
-
-      it('not when the redirected location does not match target host', function() {
-        this.proxyRes.statusCode = 302;
-        this.proxyRes.headers.location = "http://some-other/";
-        httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
-        expect(this.proxyRes.headers.location).to.eql('http://some-other/');
-      });
-
-      it('not when the redirected location does not match target port', function() {
-        this.proxyRes.statusCode = 302;
-        this.proxyRes.headers.location = "http://backend.com:8080/";
-        httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
-        expect(this.proxyRes.headers.location).to.eql('http://backend.com:8080/');
-      });
+      });     
     });
 
     context('rewrites location host with autoRewrite', function() {
@@ -87,21 +73,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
         delete this.options.autoRewrite;
         httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
         expect(this.proxyRes.headers.location).to.eql('http://backend.com/');
-      });
-
-      it('not when the redirected location does not match target host', function() {
-        this.proxyRes.statusCode = 302;
-        this.proxyRes.headers.location = "http://some-other/";
-        httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
-        expect(this.proxyRes.headers.location).to.eql('http://some-other/');
-      });
-
-      it('not when the redirected location does not match target port', function() {
-        this.proxyRes.statusCode = 302;
-        this.proxyRes.headers.location = "http://backend.com:8080/";
-        httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
-        expect(this.proxyRes.headers.location).to.eql('http://backend.com:8080/');
-      });
+      });        
     });
 
     context('rewrites location protocol with protocolRewrite', function() {


### PR DESCRIPTION
- Removed constraint that prevented rewrites when the target and redirected host did not match.
- Removed associated tests.

This constraint was added between v 1.9.x and 1.11.x and broke an implementation that was being used to proxy localhost requests to a another server.

If there's a good reason to keep preventing proxying between hosts that are not the same, I'd be interested to understand why and if there's a workaround for my specific use case. 