### PR TITLE
Use raw headers instead parsed.

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -1,5 +1,6 @@
 var http   = require('http'),
     https  = require('https'),
+    util   = require('util'),
     common = require('../common'),
     passes = exports;
 
@@ -113,12 +114,24 @@ var passes = exports;
 
       if (proxyHead && proxyHead.length) proxySocket.unshift(proxyHead);
 
-      socket.write('HTTP/1.1 101 Switching Protocols\r\n');
-      socket.write(proxyRes.rawHeaders.map(function(v, i, a) {
-        return !(i % 2) ? v + ": " + a[i+1] : null;
-      }).filter(function (v) {
-        return v ? true : false;
-      }).join('\r\n') + '\r\n\r\n');
+      var writeHead = [
+        'HTTP/1.1 101 Switching Protocols'
+      ];
+
+      Object.keys(proxyRes.headers).map(function(i) {
+          if (util.isArray(proxyRes.headers[i])) {
+            var a   = proxyRes.headers[i];
+            var len = a.length;
+
+            for (var x = 0; x < len; x++) {
+              writeHead.push(i + ": " + a[x]);
+            }
+        } else {
+          writeHead.push(i + ": " + proxyRes.headers[i]);
+        }
+      });
+
+      socket.write(writeHead.join('\r\n') + '\r\n\r\n');
       proxySocket.pipe(socket).pipe(proxySocket);
 
       server.emit('open', proxySocket);

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -114,8 +114,10 @@ var passes = exports;
       if (proxyHead && proxyHead.length) proxySocket.unshift(proxyHead);
 
       socket.write('HTTP/1.1 101 Switching Protocols\r\n');
-      socket.write(Object.keys(proxyRes.headers).map(function(i) {
-        return i + ": " + proxyRes.headers[i];
+      socket.write(proxyRes.rawHeaders.map(function(v, i, a) {
+        return !(i % 2) ? v + ": " + a[i+1] : null;
+      }).filter(function (v) {
+        return v ? true : false;
       }).join('\r\n') + '\r\n\r\n');
       proxySocket.pipe(socket).pipe(proxySocket);
 

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -118,7 +118,7 @@ var passes = exports;
         'HTTP/1.1 101 Switching Protocols'
       ];
 
-      Object.keys(proxyRes.headers).map(function(i) {
+      for(var i in proxyRes.headers) {
           if (util.isArray(proxyRes.headers[i])) {
             var a   = proxyRes.headers[i];
             var len = a.length;
@@ -129,7 +129,7 @@ var passes = exports;
         } else {
           writeHead.push(i + ": " + proxyRes.headers[i]);
         }
-      });
+      }
 
       socket.write(writeHead.join('\r\n') + '\r\n\r\n');
       proxySocket.pipe(socket).pipe(proxySocket);

--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -415,7 +415,7 @@ describe('lib/http-proxy.js', function() {
       }),
       proxyServer = proxy.listen(ports.proxy),
       destiny = new ws.Server({ port: ports.source }, function () {
-        var key = new Buffer(Math.random().toString(35)).toString('base64');
+        var key = new Buffer(Math.random().toString()).toString('base64');
         
         var requestOptions = {
           port: ports.proxy,


### PR DESCRIPTION
Set-Cookie headers are parsed into single header with cookies in array.
This messes up the Set-Cookie headers, because browser receives multiple Set-Cookie headers as single with cookies separted with comma.