### PR TITLE
fix #873. Silently drop the error to let the benchmark finish.

### DIFF
--- a/benchmark/scripts/proxy.js
+++ b/benchmark/scripts/proxy.js
@@ -3,4 +3,12 @@ var http = require('http'),
 //
 // Create your proxy server
 //
-httpProxy.createProxyServer({ target: 'http://localhost:9000' }).listen(8000);
+httpProxy.createProxyServer({ target: 'http://localhost:9000' })
+  .on('error', function(e) {
+    // Silently drop the errors without terminate the proxy.
+    // read / connection timeout errors are likely occur when performing
+    // "wrk -c 100 -d5m -t 8 http://127.0.0.1:8000". wrk will accumualate
+    // the errors.
+    // console.log(e);
+  })
+  .listen(8000);


### PR DESCRIPTION
After the fix, the benchmark can finish with proper socket errors.

➜  node-http-proxy git:(master) ✗ wrk -c 1000 -d1m -t 8 http://127.0.0.1:8000
Running 1m test @ http://127.0.0.1:8000
  8 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.05s   489.87ms   2.00s    61.01%
    Req/Sec    56.42     49.24   320.00     80.89%
  14983 requests in 1.00m, 1.79MB read
  Socket errors: connect 0, read 1692, write 0, timeout 365
Requests/sec:    249.32
Transfer/sec:     30.43KB