### PR TITLE
Updating the upgrading doc

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -92,5 +92,6 @@ which were in the core and delegate them to eventual "userland" modules.
 
 The new API makes it really easy to implement code that behaves like the old Middleware API. You can check some examples [here](https://github.com/nodejitsu/node-http-proxy/tree/caronte/examples/middleware)
 
+### ProxyTable API
 
-
+See this [link](http://blog.nodejitsu.com/node-http-proxy-1dot0/) for an example of how to add proxy table functionality using the new API.


### PR DESCRIPTION
Recently ran into a case where I had to upgrade the `http-proxy` version for an app, and that app was using a proxy table.

I'm not sure how many users are still using the 0.x.x version of `http-proxy`, but the added link (found from one of the GH issues) may encourage them to switch over to 1.x.x if they were using the old version due to its proxy table support and the activation energy to upgrade was too high.

Edit: There was some work involved in creating a proxy table to map paths to urls, disregarding the source's hostname, so I'm not sure if this would warrant creating a module (w/ source hostname support). Here's the relevant code if you also want to add it to the README:
```
    for (var pathPrefix in proxyTable) {
        if (proxyTable.hasOwnProperty(pathPrefix)) {
            if (path.indexOf(pathPrefix) === 0) {
                req.url = path.replace(pathPrefix, '');
                target = proxyTable[pathPrefix]; // this is the reverse proxy target
                break;
            }
        }
    }
```