### PR TITLE
Removed unspecified trailing slash in proxy url

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -80,7 +80,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   // Remark: Can we somehow not use url.parse as a perf optimization?
   //
   var outgoingPath = !options.toProxy
-    ? (url.parse(req.url).path || '/')
+    ? (url.parse(req.url).path || '')
     : req.url;
 
   //

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -332,7 +332,7 @@ describe('lib/http-proxy/common.js', function () {
         { path: '' }
       }, { url : '' });
 
-      expect(outgoing.path).to.be('/');
+      expect(outgoing.path).to.be('');
     });
 
   });


### PR DESCRIPTION
Previously, if target='http://localhost:9060/appEndpoint' and req.url='', the url the proxied request will hit is: 'http://localhost:9060/appEndpoint**/**'

With the change, if target='http://localhost:9060/appEndpoint' and req.url='', the url the proxied request will hit is: 'http://localhost:9060/appEndpoint'

This is helpful if the app endpoint is to a router that is sensitive to the trailing slash (e.g., a Rails router)
