### PR TITLE
Bump requires-port, server and ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "dependencies": {
     "eventemitter3": "1.x.x",
-    "requires-port": "0.x.x"
+    "requires-port": "1.x.x"
   },
   "devDependencies": {
     "async": "*",
@@ -24,10 +24,10 @@
     "expect.js": "*",
     "mocha": "*",
     "mocha-lcov-reporter": "*",
-    "semver": "^4.3.3",
+    "semver": "^5.0.3",
     "socket.io": "*",
     "socket.io-client": "*",
-    "ws": "~0.5.0"
+    "ws": "^0.8.0"
   },
   "scripts": {
     "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.

And [`requires-port`](https://github.com/unshiftio/requires-port) v1.0.0 includes a small but important fix. https://github.com/unshiftio/requires-port/pull/2
