### PR TITLE
support convert method connect to websocket

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -113,10 +113,13 @@ var passes = exports;
 
       if (proxyHead && proxyHead.length) proxySocket.unshift(proxyHead);
 
-      socket.write('HTTP/1.1 101 Switching Protocols\r\n');
-      socket.write(Object.keys(proxyRes.headers).map(function(i) {
-        return i + ": " + proxyRes.headers[i];
-      }).join('\r\n') + '\r\n\r\n');
+      if (!req.headers['x-method-ori']) {
+        // if only not switch request method, like from connect to websocket
+        socket.write('HTTP/1.1 101 Switching Protocols\r\n');
+        socket.write(Object.keys(proxyRes.headers).map(function(i) {
+          return i + ": " + proxyRes.headers[i];
+        }).join('\r\n') + '\r\n\r\n');
+      }
       proxySocket.pipe(socket).pipe(proxySocket);
 
       server.emit('open', proxySocket);


### PR DESCRIPTION
* browser access https through forward proxy1
* proxy1 will accept connect request
* proxy1 will proxy to proxy2 by upgrade/websocket
 - proxy1 will set headers[x-method-ori] to the original request method
 - proxy2 may be deployed in cloud behind a reverse proxy
 - the reverse proxy in cloud may only allow normal and websocket request
 - and forbid connect request
 - proxy2 is located in a free net env, it's not under network restriction
* proxy2 will connect to the target site, its https
* proxy2 will response with 101 switch protocol
* proxy2 will response with Connection Established next
* when proxy1 accept 101, it can not auto response with 101, but ignore it