### PR TITLE
Fix for #839 (Ignore path and the trailing slash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ proxyServer.listen(8015);
 *  **secure**: true/false, if you want to verify the SSL Certs
 *  **toProxy**: passes the absolute URL as the `path` (useful for proxying to proxies)
 *  **prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path
-*  **ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request
+*  **ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).
 *  **localAddress**: Local interface string to bind for outgoing connections
 *  **changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL
 *  **auth**: Basic authentication i.e. 'user:password' to compute an Authorization header.  

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -88,7 +88,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   // path is. This can be labeled as FOOT-GUN material if you do not know what
   // you are doing and are using conflicting options.
   //
-  outgoingPath = !options.ignorePath ? outgoingPath : '/';
+  outgoingPath = !options.ignorePath ? outgoingPath : '';
 
   outgoing.path = common.urlJoin(targetPath, outgoingPath);
 

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -250,7 +250,7 @@ describe('lib/http-proxy/common.js', function () {
           ignorePath: true
         }, { url: '/more/crazy/pathness' });
 
-        expect(outgoing.path).to.eql('/some/crazy/path/whoooo/');
+        expect(outgoing.path).to.eql('/some/crazy/path/whoooo');
       });
 
       it('and prependPath: false, it should ignore path of target and incoming request', function () {
@@ -262,7 +262,7 @@ describe('lib/http-proxy/common.js', function () {
           prependPath: false
         }, { url: '/more/crazy/pathness' });
 
-        expect(outgoing.path).to.eql('/');
+        expect(outgoing.path).to.eql('');
       });
     });
 


### PR DESCRIPTION
When using option ignorePath common.js would set target to '/'.

This would break requests in cases where this slash was unwanted, for instance when fetching files, or in some cases when using GET parameters.