### PR TITLE
Added check to passes/web-outgoing.js to make sure the header being s…

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -82,7 +82,9 @@ var redirectRegex = /^30(1|2|7|8)$/;
    */
   function writeHeaders(req, res, proxyRes) {
     Object.keys(proxyRes.headers).forEach(function(key) {
-      res.setHeader(key, proxyRes.headers[key]);
+      if(proxyRes.headers[key] != undefined){
+        res.setHeader(key, proxyRes.headers[key]);
+      }
     });
   },
 


### PR DESCRIPTION
…et is not undefined, which should be the only falsey value that could accidently show up and break that call. This fixes windows NTLM auth issues behind http-proxy in issue [#938](https://github.com/nodejitsu/node-http-proxy/issues/938).