### PR TITLE
fix(common) urlJoin replace: ":/" -> "http?s:/"

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -182,7 +182,10 @@ common.urlJoin = function() {
   // joining e.g. ['', 'am']
   //
   retSegs = [
-    args.filter(Boolean).join('/').replace(/\/+/g, '/').replace(/:\//g, '://')
+    args.filter(Boolean).join('/')
+        .replace(/\/+/g, '/')
+        .replace('http:/', 'http://')
+        .replace('https:/', 'https://')
   ];
 
   // Only join the query string if it exists so we don't have trailing a '?'

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -241,6 +241,28 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.path).to.eql('/' + google);
     });
 
+    it('should not replace :\ to :\\ when no https word before', function () {
+      var outgoing = {};
+      var google = 'https://google.com:/join/join.js'
+      common.setupOutgoing(outgoing, {
+        target: url.parse('http://sometarget.com:80'),
+        toProxy: true,
+      }, { url: google });
+
+      expect(outgoing.path).to.eql('/' + google);
+    });
+    
+    it('should not replace :\ to :\\ when no http word before', function () {
+      var outgoing = {};
+      var google = 'http://google.com:/join/join.js'
+      common.setupOutgoing(outgoing, {
+        target: url.parse('http://sometarget.com:80'),
+        toProxy: true,
+      }, { url: google });
+
+      expect(outgoing.path).to.eql('/' + google);
+    });
+    
     describe('when using ignorePath', function () {
       it('should ignore the path of the `req.url` passed in but use the target path', function () {
         var outgoing = {};


### PR DESCRIPTION
Shrunk replace options.
Fix https://github.com/nodejitsu/node-http-proxy/issues/946.