### PR TITLE
[fix] pass more useful information to the error that we dont already …

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -127,17 +127,14 @@ web_o = Object.keys(web_o).map(function(pass) {
       proxyReq.abort();
     });
 
-    // Handle errors on incoming request as well as it makes sense to
-    req.on('error', proxyError);
-
     // Error Handler
     proxyReq.on('error', proxyError);
 
     function proxyError (err){
       if (clb) {
-        clb(err, req, res, options.target);
+        clb(err, proxyReq, options.target);
       } else {
-        server.emit('error', err, req, res, options.target);
+        server.emit('error', err, proxyReq, options.target);
       }
     }
 

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -144,11 +144,9 @@ describe('#createProxyServer.web() using own http server', function () {
     var proxyServer = http.createServer(requestHandler);
 
     function requestHandler(req, res) {
-      proxy.once('error', function (err, errReq, errRes) {
+      proxy.once('error', function (err) {
         proxyServer.close();
         expect(err).to.be.an(Error);
-        expect(errReq).to.be.equal(req);
-        expect(errRes).to.be.equal(res);
         expect(err.code).to.be('ECONNREFUSED');
         done();
       });
@@ -177,11 +175,9 @@ describe('#createProxyServer.web() using own http server', function () {
 
     var started = new Date().getTime();
     function requestHandler(req, res) {
-      proxy.once('error', function (err, errReq, errRes) {
+      proxy.once('error', function (err) {
         proxyServer.close();
         expect(err).to.be.an(Error);
-        expect(errReq).to.be.equal(req);
-        expect(errRes).to.be.equal(res);
         expect(new Date().getTime() - started).to.be.greaterThan(99);
         expect(err.code).to.be('ECONNRESET');
         done();
@@ -217,11 +213,9 @@ describe('#createProxyServer.web() using own http server', function () {
 
     var started = new Date().getTime();
     function requestHandler(req, res) {
-      proxy.once('error', function (err, errReq, errRes) {
+      proxy.once('error', function (err) {
         proxyServer.close();
         expect(err).to.be.an(Error);
-        expect(errReq).to.be.equal(req);
-        expect(errRes).to.be.equal(res);
         expect(err.code).to.be('ECONNRESET');
         doneOne();
       });


### PR DESCRIPTION
So the caveat here is that this is a breaking change, but i think it provides more useful context to the `error` as the `error` should be the actual `proxyReq` and not the `req` itself. In most cases (or at least using the `callback` api, you already have access to `req` and `res` so providing these ends up being useless. We were also previously capturing errors from client requests which I believe was creating false positives for people.

Thoughts @donasaur @indexzero 