### PR TITLE
mocha: Use default reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "blanket": {
       "pattern": "lib/http-proxy"
     },
-    "test": "mocha -R landing test/*-test.js",
+    "test": "mocha test/*-test.js",
     "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
   },
   "engines": {


### PR DESCRIPTION
This PR switches `npm test` to using the default mocha reporter. The "landing" reporter doesn't render well on CI servers like TravisCI.