### PR TITLE
Catch invalid headers

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -17,7 +17,7 @@ var redirectRegex = /^30(1|2|7|8)$/;
    * If is a HTTP 1.0 request, remove chunk headers
    *
    * @param {ClientRequest} Req Request object
-   * @param {IncomingMessage} Res Response object
+   * @param {IncomingMessage} Res Response object
    * @param {proxyResponse} Res Response object from the proxy request
    *
    * @api private
@@ -33,7 +33,7 @@ var redirectRegex = /^30(1|2|7|8)$/;
    * or if connection header not present, then use `keep-alive`
    *
    * @param {ClientRequest} Req Request object
-   * @param {IncomingMessage} Res Response object
+   * @param {IncomingMessage} Res Response object
    * @param {proxyResponse} Res Response object from the proxy request
    *
    * @api private
@@ -75,24 +75,28 @@ var redirectRegex = /^30(1|2|7|8)$/;
    * set each header in response object.
    *
    * @param {ClientRequest} Req Request object
-   * @param {IncomingMessage} Res Response object
+   * @param {IncomingMessage} Res Response object
    * @param {proxyResponse} Res Response object from the proxy request
    *
    * @api private
    */
   function writeHeaders(req, res, proxyRes) {
     Object.keys(proxyRes.headers).forEach(function(key) {
-      if(proxyRes.headers[key] != undefined){
-        res.setHeader(key, proxyRes.headers[key]);
+      if (proxyRes.headers[key] != undefined) {
+        try {
+          res.setHeader(key, proxyRes.headers[key]);
+        } catch (e) {
+          // ignore invalid headers
+        }
       }
     });
   },
-
+  
   /**
    * Set the statusCode from the proxyResponse
    *
    * @param {ClientRequest} Req Request object
-   * @param {IncomingMessage} Res Response object
+   * @param {IncomingMessage} Res Response object
    * @param {proxyResponse} Res Response object from the proxy request
    *
    * @api private

--- a/test/lib-http-proxy-passes-ws-incoming-test.js
+++ b/test/lib-http-proxy-passes-ws-incoming-test.js
@@ -15,7 +15,7 @@ describe('lib/http-proxy/passes/ws-incoming.js', function () {
           destroyCalled = true;
         }
       }
-      returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
+      var returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
       expect(returnValue).to.be(true);
       expect(destroyCalled).to.be(true);
     })
@@ -32,7 +32,7 @@ describe('lib/http-proxy/passes/ws-incoming.js', function () {
           destroyCalled = true;
         }
       }
-      returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
+      var returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
       expect(returnValue).to.be(true);
       expect(destroyCalled).to.be(true);
     })
@@ -51,7 +51,7 @@ describe('lib/http-proxy/passes/ws-incoming.js', function () {
           destroyCalled = true;
         }
       }
-      returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
+      var returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
       expect(returnValue).to.be(true);
       expect(destroyCalled).to.be(true);
     })
@@ -70,7 +70,7 @@ describe('lib/http-proxy/passes/ws-incoming.js', function () {
           destroyCalled = true;
         }
       }
-      returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
+      var returnValue = httpProxy.checkMethodAndHeader(stubRequest, stubSocket);
       expect(returnValue).to.be(undefined);
       expect(destroyCalled).to.be(false);
     })

--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -1,7 +1,7 @@
 var httpProxy = require('../lib/http-proxy'),
     expect    = require('expect.js'),
     http      = require('http'),
-    ws        = require('ws')
+    ws        = require('ws'),
     io        = require('socket.io'),
     SSE       = require('sse'),
     ioClient  = require('socket.io-client');

--- a/test/lib-https-proxy-test.js
+++ b/test/lib-https-proxy-test.js
@@ -1,7 +1,7 @@
 var httpProxy = require('../lib/http-proxy'),
     semver    = require('semver'),
     expect    = require('expect.js'),
-    http      = require('http')
+    http      = require('http'),
     https     = require('https'),
     path      = require('path'),
     fs        = require('fs');


### PR DESCRIPTION
fixes https://github.com/nodejitsu/node-http-proxy/issues/964

I've opted to wrap the setHeader call into a try/catch so I don't have to duplicate the code from node.js and `storeHeader` can also throw for other reasons.