### PR TITLE
Emit disconnected event instead of error when ECONNRESET

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -132,7 +132,15 @@ web_o = Object.keys(web_o).map(function(pass) {
     req.on('error', proxyError);
 
     // Error Handler
-    proxyReq.on('error', proxyError);
+    proxyReq.on('error', function (err) {
+        if (req.socket.destroyed && err.code === 'ECONNRESET') {
+          server.emit('disconnected', err, req, res, options.target);
+          proxyReq.abort();
+        } else {
+          proxyError(err);
+        }
+    });
+
 
     function proxyError (err){
       if (clb) {

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -132,17 +132,14 @@ web_o = Object.keys(web_o).map(function(pass) {
     req.on('error', proxyError);
 
     // Error Handler
-    proxyReq.on('error', function (err) {
-        if (req.socket.destroyed && err.code === 'ECONNRESET') {
-          server.emit('disconnected', err, req, res, options.target);
-          proxyReq.abort();
-        } else {
-          proxyError(err);
-        }
-    });
-
+    proxyReq.on('error', proxyError);
 
     function proxyError (err){
+      if (req.socket.destroyed && err.code === 'ECONNRESET') {
+        server.emit('econnreset', err, req, res, options.target);
+        return proxyReq.abort();
+      }
+
       if (clb) {
         clb(err, req, res, options.target);
       } else {

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -229,7 +229,7 @@ describe('#createProxyServer.web() using own http server', function () {
 
     var started = new Date().getTime();
     function requestHandler(req, res) {
-      proxy.once('error', function (err, errReq, errRes) {
+      proxy.once('disconnected', function (err, errReq, errRes) {
         proxyServer.close();
         expect(err).to.be.an(Error);
         expect(errReq).to.be.equal(req);

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -229,7 +229,7 @@ describe('#createProxyServer.web() using own http server', function () {
 
     var started = new Date().getTime();
     function requestHandler(req, res) {
-      proxy.once('disconnected', function (err, errReq, errRes) {
+      proxy.once('econnreset', function (err, errReq, errRes) {
         proxyServer.close();
         expect(err).to.be.an(Error);
         expect(errReq).to.be.equal(req);


### PR DESCRIPTION
Hello folks, 
This is my first contribution, if there is anything wrong with my PR, please let me know.

We've been using node-http-proxy in our prod server since 3 years now and its working as a charm (thank you!), but everyday we got our log files full of `socket hang up` messages, so I come here dig code and found an issue for that: #[813](https://github.com/nodejitsu/node-http-proxy/issues/813). 

To me, this looks like a bug also, we should not send as an error a disconnection between the client, so I made this PR using the info in the issue.

I'm not sure if emit a `disconnected` event is the best approach, or if you guys want something more elaborate for that. Please, let me know your thoughts.