### PR TITLE
Set the x-forwarded-host flag when xfwd is enabled

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -78,6 +78,8 @@ web_o = Object.keys(web_o).map(function(pass) {
         (req.headers['x-forwarded-' + header] ? ',' : '') +
         values[header];
     });
+    
+    req.headers['x-forwarded-host'] = req.headers['host'];
   },
 
   /**


### PR DESCRIPTION
Reasoning: Rack's request class [makes use of](https://github.com/rack/rack/blob/master/lib/rack/request.rb#L243) this HTTP header. Certain edge-case scenarios (proxying from ember-cli to a Rails backend) can be problematic without this header being present.

/cc @perlun, @jesjos