### PR TITLE
Fix formatting of the `headers` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ proxyServer.listen(8015);
 *  **hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.
 *  **autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.
 *  **protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.
- *  **headers**: object with extra headers to be added to target requests.
+*  **headers**: object with extra headers to be added to target requests.
 
 **NOTE:**  
 `options.ws` and `options.ssl` are optional.  


### PR DESCRIPTION
### Before
<img width="873" alt="screen shot 2016-03-08 at 6 06 30 pm" src="https://cloud.githubusercontent.com/assets/54056/13619712/aeaaaa2c-e558-11e5-9aa1-1cf83428f9cd.png">

### After
<img width="866" alt="screen shot 2016-03-08 at 6 07 31 pm" src="https://cloud.githubusercontent.com/assets/54056/13619711/aeaadf92-e558-11e5-9c2e-4393c3a0d168.png">
