### PR TITLE
Adding ability to intercept and alter websocket messages.

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -1,7 +1,11 @@
 var http   = require('http'),
     https  = require('https'),
     common = require('../common'),
-    passes = exports;
+    passes = exports,
+    PerMessageDeflate = require('ws/lib/PerMessageDeflate'),
+    Extensions = require('ws/lib/Extensions'),
+    Receiver = require('ws/lib/Receiver'),
+    Sender = require('ws/lib/Sender');
 
 /*!
  * Array of passes.
@@ -138,7 +142,115 @@ var passes = exports;
         .join('\r\n') + '\r\n\r\n'
       );
 
-      proxySocket.pipe(socket).pipe(proxySocket);
+      function acceptExtensions(offer, isServer) {
+        var extensions = {};
+        if (offer[PerMessageDeflate.extensionName]) {
+          var perMessageDeflate = new PerMessageDeflate({}, isServer);
+          perMessageDeflate.accept(offer[PerMessageDeflate.extensionName]);
+          extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
+        }
+        return extensions;
+      }
+
+      ////////////////////////////////////////////////////////////////////////
+      // [Client] -> [ProxyServer] <-> [ProxyClient] -> [Server]
+      // socket is the [Client] / proxySocket is the [Server]
+
+      // This section is handling: [ProxyClient] -> [Server]
+      // Parse the extensions, typically set to something like: permessage-deflate; client_max_window_bits=15
+      var isCompressed = 'sec-websocket-extensions' in proxyRes.headers && proxyRes.headers['sec-websocket-extensions'].contains('permessage-deflate')
+      var offer = Extensions.parse(proxyRes.headers['sec-websocket-extensions']);
+      // We need both client/server versions of the extensions for each side of the proxy connection
+      var extensionsAsServer = isCompressed ? acceptExtensions(offer, false) : null;
+      var extensionsAsClient = isCompressed ? acceptExtensions(offer, true) : null;
+      // Receiver takes socket stream data and reconstructs and emits web socket messages
+      var toServerReceiver = new Receiver(extensionsAsServer);
+      // Sender takes raw data and composes packaged messages to send through the websocket
+      var toServerSender = new Sender(proxySocket, extensionsAsClient);
+      // Wrapped so we can expose this with the correct options
+      var toServerSenderFunction = function(data, binary) {
+        // Server needs masking enabled see WebSocket RFC: Client-to-Server Masking
+        // If this is not set, the websocket will fail to connect
+        var sendOptions = { fin: true, mask: true, compress: isCompressed, binary: !!binary };
+        proxyReq.emit('message_toserver', data, binary);
+        toServerSender.send(data, sendOptions);
+      }
+
+      // Callback when a websocket text message is received
+      toServerReceiver.ontext = function(data, flags) {
+        if (typeof (options.wsOnMessageToServer) === 'function') {
+          data = options.wsOnMessageToServer(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toServerSenderFunction(data);
+          }
+        }
+        else {
+          toServerSenderFunction(data);
+        }
+      };
+
+      // Callback when a websocket binary message is received
+      toServerReceiver.onbinary = function(data, flags) {
+        if (typeof (options.wsOnMessageToServer) === 'function') {
+          data = options.wsOnMessageToServer(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toServerSenderFunction(data, true);
+          }
+        }
+        else {
+          toServerSenderFunction(data, true);
+        }
+      };
+
+      // Accept stream data from the socket and add it into the websocket receiver in order to retreive messages
+      socket.on('data', function(data) {
+        toServerReceiver.add(data);
+      });
+
+      ////////////////////////////////////////////////////////////////////////
+      // This section is handling: [Client] -> [ProxyServer]
+      var toClientReceiver = new Receiver(extensionsAsClient);
+      var toClientSender = new Sender(socket, extensionsAsServer);
+      // Wrapped so we can expose this with the correct options
+      var toClientSenderFunction = function(data, binary) {
+        var sendOptions = { fin: true, mask: false, compress: isCompressed, binary: false };
+        proxyReq.emit('message_toclient', data, binary);
+        toClientSender.send(data, sendOptions);
+      }
+      toClientReceiver.ontext = function(data, flags) {
+        if (typeof (options.wsOnMessageToClient) === 'function') {
+          data = options.wsOnMessageToClient(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toClientSenderFunction(data);
+          }
+        }
+        else {
+          toClientSenderFunction(data);
+        }
+      };
+
+      toClientReceiver.onbinary = function(data, flags) {
+        if (typeof (options.wsOnMessageToClient) === 'function') {
+          data = options.wsOnMessageToClient(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toClientSenderFunction(data, true);
+          }
+        }
+        else {
+          toClientSenderFunction(data, true);
+        }
+      };
+
+      proxySocket.on('data', function(data) {
+        toClientReceiver.add(data);
+        // socket.write(data);
+      });
+
+      if (server) { server.emit('websocket_connected', toServerSenderFunction, toClientSenderFunction); }
 
       server.emit('open', proxySocket);
       server.emit('proxySocket', proxySocket);  //DEPRECATED.


### PR DESCRIPTION
I created some changes in order to help facility intercepting and modifying websocket messages.  I highly doubt this is something you would want to take in as is, but proved to be valuable to me and will hopefully for others.

When calling createProxyServer define callback functions in order to modify (and observe) the websocket message.
```javascript
var proxySettings = {
  // ...
  ws: true,
    wsOnMessageToClient: function(data, flags) {
    // modify or observe data
    return yourModifyingFunction(data);
  },
  wsOnMessageToServer: function(data, flags) {
    // modify or observe data
    return data;
  }
};
```

You can also attach event listeners to only observe the messages.
```javascript
var proxy = httpProxy.createProxyServer(proxySettings)
  .on('proxyReqWs', function(proxyReqWs, req, clientSocket) {
    proxyReqWs.on('upgrade', function(res, serverSocket) {
      proxyReqWs
        .on('message_toserver', function(data, flags) {
          console.log('TOSERVER:', data);
        }).on('message_toclient', function(data, flags) {
          console.log('TOCLIENT:', data);
        });
    });
```
