### PR TITLE
Added ability to intercept and manipulate web socket messages

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -1,11 +1,7 @@
 var http   = require('http'),
     https  = require('https'),
     common = require('../common'),
-    passes = exports,
-    PerMessageDeflate = require('ws/lib/PerMessageDeflate'),
-    Extensions = require('ws/lib/Extensions'),
-    Receiver = require('ws/lib/Receiver'),
-    Sender = require('ws/lib/Sender');
+    passes = exports;
 
 /*!
  * Array of passes.
@@ -142,115 +138,133 @@ var passes = exports;
         .join('\r\n') + '\r\n\r\n'
       );
 
-      function acceptExtensions(offer, isServer) {
-        var extensions = {};
-        if (offer[PerMessageDeflate.extensionName]) {
-          var perMessageDeflate = new PerMessageDeflate({}, isServer);
-          perMessageDeflate.accept(offer[PerMessageDeflate.extensionName]);
-          extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
+      function setupInterceptingWebSocket() {
+        var PerMessageDeflate = require('ws/lib/PerMessageDeflate'),
+            Extensions        = require('ws/lib/Extensions'),
+            Receiver          = require('ws/lib/Receiver'),
+            Sender            = require('ws/lib/Sender');
+
+        // Needed to catch the pipe closing, and notifying the consumer
+        proxyReq.on('close', function(data) {
+          server.emit('close', proxyRes, proxySocket, proxyHead);
+        });
+
+        function acceptExtensions(offer, isServer) {
+          var extensions = {};
+          if (offer[PerMessageDeflate.extensionName]) {
+            var perMessageDeflate = new PerMessageDeflate({}, isServer);
+            perMessageDeflate.accept(offer[PerMessageDeflate.extensionName]);
+            extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
+          }
+          return extensions;
         }
-        return extensions;
-      }
 
-      ////////////////////////////////////////////////////////////////////////
-      // [Client] -> [ProxyServer] <-> [ProxyClient] -> [Server]
-      // socket is the [Client] / proxySocket is the [Server]
+        ////////////////////////////////////////////////////////////////////////
+        // [Client] -> [ProxyServer] <-> [ProxyClient] -> [Server]
+        // socket is the [Client] / proxySocket is the [Server]
 
-      // This section is handling: [ProxyClient] -> [Server]
-      // Parse the extensions, typically set to something like: permessage-deflate; client_max_window_bits=15
-      var isCompressed = 'sec-websocket-extensions' in proxyRes.headers && proxyRes.headers['sec-websocket-extensions'].contains('permessage-deflate')
-      var offer = Extensions.parse(proxyRes.headers['sec-websocket-extensions']);
-      // We need both client/server versions of the extensions for each side of the proxy connection
-      var extensionsAsServer = isCompressed ? acceptExtensions(offer, false) : null;
-      var extensionsAsClient = isCompressed ? acceptExtensions(offer, true) : null;
-      // Receiver takes socket stream data and reconstructs and emits web socket messages
-      var toServerReceiver = new Receiver(extensionsAsServer);
-      // Sender takes raw data and composes packaged messages to send through the websocket
-      var toServerSender = new Sender(proxySocket, extensionsAsClient);
-      // Wrapped so we can expose this with the correct options
-      var toServerSenderFunction = function(data, binary) {
-        // Server needs masking enabled see WebSocket RFC: Client-to-Server Masking
-        // If this is not set, the websocket will fail to connect
-        var sendOptions = { fin: true, mask: true, compress: isCompressed, binary: !!binary };
-        proxyReq.emit('message_toserver', data, binary);
-        toServerSender.send(data, sendOptions);
-      }
+        // This section is handling: [ProxyClient] -> [Server]
+        // Parse the extensions, typically set to something like: permessage-deflate; client_max_window_bits=15
+        var isCompressed = ('sec-websocket-extensions' in proxyRes.headers) && (proxyRes.headers['sec-websocket-extensions'].indexOf('permessage-deflate') != -1);
+        var offer = Extensions.parse(proxyRes.headers['sec-websocket-extensions']);
+        // We need both client/server versions of the extensions for each side of the proxy connection
+        var extensionsAsServer = isCompressed ? acceptExtensions(offer, false) : null;
+        var extensionsAsClient = isCompressed ? acceptExtensions(offer, true) : null;
+        // Receiver takes socket stream data and reconstructs and emits web socket messages
+        var toServerReceiver = new Receiver(extensionsAsServer);
+        // Sender takes raw data and composes packaged messages to send through the websocket
+        var toServerSender = new Sender(proxySocket, extensionsAsClient);
+        // Wrapped so we can expose this with the correct options
+        var toServerSenderFunction = function(data, binary) {
+          // Server needs masking enabled see WebSocket RFC: Client-to-Server Masking
+          // If this is not set, the websocket will fail to connect
+          var sendOptions = { fin: true, mask: true, compress: isCompressed, binary: !!binary };
+          proxyReq.emit('message_toserver', data, binary);
+          toServerSender.send(data, sendOptions);
+        }
 
-      // Callback when a websocket text message is received
-      toServerReceiver.ontext = function(data, flags) {
-        if (typeof (options.wsOnMessageToServer) === 'function') {
-          data = options.wsOnMessageToServer(data, flags);
-          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
-          if (data) {
+        // Callback when a websocket text message is received
+        toServerReceiver.ontext = function(data, flags) {
+          if (typeof (options.wsOnMessageToServer) === 'function') {
+            data = options.wsOnMessageToServer(data, flags);
+            // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+            if (data) {
+              toServerSenderFunction(data);
+            }
+          }
+          else {
             toServerSenderFunction(data);
           }
-        }
-        else {
-          toServerSenderFunction(data);
-        }
-      };
+        };
 
-      // Callback when a websocket binary message is received
-      toServerReceiver.onbinary = function(data, flags) {
-        if (typeof (options.wsOnMessageToServer) === 'function') {
-          data = options.wsOnMessageToServer(data, flags);
-          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
-          if (data) {
+        // Callback when a websocket binary message is received
+        toServerReceiver.onbinary = function(data, flags) {
+          if (typeof (options.wsOnMessageToServer) === 'function') {
+            data = options.wsOnMessageToServer(data, flags);
+            // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+            if (data) {
+              toServerSenderFunction(data, true);
+            }
+          }
+          else {
             toServerSenderFunction(data, true);
           }
-        }
-        else {
-          toServerSenderFunction(data, true);
-        }
-      };
+        };
 
-      // Accept stream data from the socket and add it into the websocket receiver in order to retreive messages
-      socket.on('data', function(data) {
-        toServerReceiver.add(data);
-      });
+        // Accept stream data from the socket and add it into the websocket receiver in order to retreive messages
+        socket.on('data', function(data) {
+          toServerReceiver.add(data);
+        });
 
-      ////////////////////////////////////////////////////////////////////////
-      // This section is handling: [Client] -> [ProxyServer]
-      var toClientReceiver = new Receiver(extensionsAsClient);
-      var toClientSender = new Sender(socket, extensionsAsServer);
-      // Wrapped so we can expose this with the correct options
-      var toClientSenderFunction = function(data, binary) {
-        var sendOptions = { fin: true, mask: false, compress: isCompressed, binary: false };
-        proxyReq.emit('message_toclient', data, binary);
-        toClientSender.send(data, sendOptions);
-      }
-      toClientReceiver.ontext = function(data, flags) {
-        if (typeof (options.wsOnMessageToClient) === 'function') {
-          data = options.wsOnMessageToClient(data, flags);
-          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
-          if (data) {
+        ////////////////////////////////////////////////////////////////////////
+        // This section is handling: [Client] -> [ProxyServer]
+        var toClientReceiver = new Receiver(extensionsAsClient);
+        var toClientSender = new Sender(socket, extensionsAsServer);
+        // Wrapped so we can expose this with the correct options
+        var toClientSenderFunction = function(data, binary) {
+          var sendOptions = { fin: true, mask: false, compress: isCompressed, binary: false };
+          proxyReq.emit('message_toclient', data, binary);
+          toClientSender.send(data, sendOptions);
+        }
+        toClientReceiver.ontext = function(data, flags) {
+          if (typeof (options.wsOnMessageToClient) === 'function') {
+            data = options.wsOnMessageToClient(data, flags);
+            // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+            if (data) {
+              toClientSenderFunction(data);
+            }
+          }
+          else {
             toClientSenderFunction(data);
           }
-        }
-        else {
-          toClientSenderFunction(data);
-        }
-      };
+        };
 
-      toClientReceiver.onbinary = function(data, flags) {
-        if (typeof (options.wsOnMessageToClient) === 'function') {
-          data = options.wsOnMessageToClient(data, flags);
-          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
-          if (data) {
+        toClientReceiver.onbinary = function(data, flags) {
+          if (typeof (options.wsOnMessageToClient) === 'function') {
+            data = options.wsOnMessageToClient(data, flags);
+            // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+            if (data) {
+              toClientSenderFunction(data, true);
+            }
+          }
+          else {
             toClientSenderFunction(data, true);
           }
-        }
-        else {
-          toClientSenderFunction(data, true);
-        }
-      };
+        };
 
-      proxySocket.on('data', function(data) {
-        toClientReceiver.add(data);
-        // socket.write(data);
-      });
+        proxySocket.on('data', function(data) {
+          toClientReceiver.add(data);
+        });
 
-      if (server) { server.emit('websocket_connected', toServerSenderFunction, toClientSenderFunction); }
+        if (server) { server.emit('websocket_connected', toServerSenderFunction, toClientSenderFunction); }
+      }
+
+      if (options.wsInterceptMessages) {
+        setupInterceptingWebSocket();
+      }
+      else {
+        proxySocket.pipe(socket).pipe(proxySocket);
+      }
 
       server.emit('open', proxySocket);
       server.emit('proxySocket', proxySocket);  //DEPRECATED.

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -1,7 +1,11 @@
 var http   = require('http'),
     https  = require('https'),
     common = require('../common'),
-    passes = exports;
+    passes = exports,
+    PerMessageDeflate = require('ws/lib/PerMessageDeflate'),
+    Extensions = require('ws/lib/Extensions'),
+    Receiver = require('ws/lib/Receiver'),
+    Sender = require('ws/lib/Sender');
 
 /*!
  * Array of passes.
@@ -138,7 +142,115 @@ var passes = exports;
         .join('\r\n') + '\r\n\r\n'
       );
 
-      proxySocket.pipe(socket).pipe(proxySocket);
+      function acceptExtensions(offer, isServer) {
+        var extensions = {};
+        if (offer[PerMessageDeflate.extensionName]) {
+          var perMessageDeflate = new PerMessageDeflate({}, isServer);
+          perMessageDeflate.accept(offer[PerMessageDeflate.extensionName]);
+          extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
+        }
+        return extensions;
+      }
+
+      ////////////////////////////////////////////////////////////////////////
+      // [Client] -> [ProxyServer] <-> [ProxyClient] -> [Server]
+      // socket is the [Client] / proxySocket is the [Server]
+
+      // This section is handling: [ProxyClient] -> [Server]
+      // Parse the extensions, typically set to something like: permessage-deflate; client_max_window_bits=15
+      var isCompressed = 'sec-websocket-extensions' in proxyRes.headers && proxyRes.headers['sec-websocket-extensions'].contains('permessage-deflate')
+      var offer = Extensions.parse(proxyRes.headers['sec-websocket-extensions']);
+      // We need both client/server versions of the extensions for each side of the proxy connection
+      var extensionsAsServer = isCompressed ? acceptExtensions(offer, false) : null;
+      var extensionsAsClient = isCompressed ? acceptExtensions(offer, true) : null;
+      // Receiver takes socket stream data and reconstructs and emits web socket messages
+      var toServerReceiver = new Receiver(extensionsAsServer);
+      // Sender takes raw data and composes packaged messages to send through the websocket
+      var toServerSender = new Sender(proxySocket, extensionsAsClient);
+      // Wrapped so we can expose this with the correct options
+      var toServerSenderFunction = function(data, binary) {
+        // Server needs masking enabled see WebSocket RFC: Client-to-Server Masking
+        // If this is not set, the websocket will fail to connect
+        var sendOptions = { fin: true, mask: true, compress: isCompressed, binary: !!binary };
+        proxyReq.emit('message_toserver', data, binary);
+        toServerSender.send(data, sendOptions);
+      }
+
+      // Callback when a websocket text message is received
+      toServerReceiver.ontext = function(data, flags) {
+        if (typeof (options.wsOnMessageToServer) === 'function') {
+          data = options.wsOnMessageToServer(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toServerSenderFunction(data);
+          }
+        }
+        else {
+          toServerSenderFunction(data);
+        }
+      };
+
+      // Callback when a websocket binary message is received
+      toServerReceiver.onbinary = function(data, flags) {
+        if (typeof (options.wsOnMessageToServer) === 'function') {
+          data = options.wsOnMessageToServer(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toServerSenderFunction(data, true);
+          }
+        }
+        else {
+          toServerSenderFunction(data, true);
+        }
+      };
+
+      // Accept stream data from the socket and add it into the websocket receiver in order to retreive messages
+      socket.on('data', function(data) {
+        toServerReceiver.add(data);
+      });
+
+      ////////////////////////////////////////////////////////////////////////
+      // This section is handling: [Client] -> [ProxyServer]
+      var toClientReceiver = new Receiver(extensionsAsClient);
+      var toClientSender = new Sender(socket, extensionsAsServer);
+      // Wrapped so we can expose this with the correct options
+      var toClientSenderFunction = function(data, binary) {
+        var sendOptions = { fin: true, mask: false, compress: isCompressed, binary: false };
+        proxyReq.emit('message_toclient', data, binary);
+        toClientSender.send(data, sendOptions);
+      }
+      toClientReceiver.ontext = function(data, flags) {
+        if (typeof (options.wsOnMessageToClient) === 'function') {
+          data = options.wsOnMessageToClient(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toClientSenderFunction(data);
+          }
+        }
+        else {
+          toClientSenderFunction(data);
+        }
+      };
+
+      toClientReceiver.onbinary = function(data, flags) {
+        if (typeof (options.wsOnMessageToClient) === 'function') {
+          data = options.wsOnMessageToClient(data, flags);
+          // TODO: might be legit to send an empty message, and we are using it as a sentinal value to indicate we consumed the message
+          if (data) {
+            toClientSenderFunction(data, true);
+          }
+        }
+        else {
+          toClientSenderFunction(data, true);
+        }
+      };
+
+      proxySocket.on('data', function(data) {
+        toClientReceiver.add(data);
+        // socket.write(data);
+      });
+
+      if (server) { server.emit('websocket_connected', toServerSenderFunction, toClientSenderFunction); }
 
       server.emit('open', proxySocket);
       server.emit('proxySocket', proxySocket);  //DEPRECATED.


### PR DESCRIPTION
I offer this PR up in case this functionality is desired for node-http-proxy - I needed this ability, but couldn't find it anywhere and thought someone else might find it useful.  Thanks for the solid code.

I've isolated this ability away from the normal proxy behavior.  If you set `wsInterceptMessages` to `true` in the options then it will intercept and relay websocket messages.

In options:
`wsOnMessageToServer` - Is a function called when a message is intercepted on its way to the server.  It takes two arguments: data is a websocket message in a Buffer class, and flags describe the message (compressed, binary, etc - from the websocket ws/lib/Receiver and Sender classes.  This function is expected to return a buffer that is to be used for the websocket message.  If `null` is returned, the message is consumed and nothing will be forwarded along the websocket proxy.
`wsOnMessageToClient` - Is a function called when a message is intercepted on its way to the client.  It also takes the same arguments as `wsOnMessageToServer`

Events:
`message_toserver` - Emitted on message to server, can be used in place of the functions if you only wish to monitor and not modify the messages.
`message_toclient` - Same as above for client.
`websocket_connected` - Emitted when websocket interception setup is complete.
