### PR TITLE
Close the connection when target sends "Connection: close" header

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -137,6 +137,12 @@ web_o = Object.keys(web_o).map(function(pass) {
     proxyReq.on('error', proxyError);
 
     function proxyError (err){
+      if (err.code === 'ECONNRESET' && proxyReq._headers && proxyReq._headers.connection === 'close') {
+        // The target server has closed the connection, but since it first sent
+        // a 'Connection: close' header this is not an error.
+        return;
+      }
+
       if (clb) {
         clb(err, req, res, options.target);
       } else {
@@ -147,11 +153,6 @@ web_o = Object.keys(web_o).map(function(pass) {
     (options.buffer || req).pipe(proxyReq);
 
     proxyReq.on('response', function(proxyRes) {
-      // Respect the target server's wish to close the connection
-      if(proxyRes.headers.connection && proxyRes.headers.connection === 'close') {
-        proxyRes.connection.destroy();
-      }
-
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
       for(var i=0; i < web_o.length; i++) {
         if(web_o[i](req, res, proxyRes, options)) { break; }

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -78,7 +78,7 @@ web_o = Object.keys(web_o).map(function(pass) {
         (req.headers['x-forwarded-' + header] ? ',' : '') +
         values[header];
     });
-    
+
     req.headers['x-forwarded-host'] = req.headers['host'];
   },
 
@@ -147,6 +147,11 @@ web_o = Object.keys(web_o).map(function(pass) {
     (options.buffer || req).pipe(proxyReq);
 
     proxyReq.on('response', function(proxyRes) {
+      // Respect the target server's wish to close the connection
+      if(proxyRes.headers.connection && proxyRes.headers.connection === 'close') {
+        proxyRes.connection.destroy();
+      }
+
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
       for(var i=0; i < web_o.length; i++) {
         if(web_o[i](req, res, proxyRes, options)) { break; }


### PR DESCRIPTION
This prevents ECONNRESET errors from being thrown for connections
that are supposed to be closed (fixes #1000).