### PR TITLE
update modifyResponse middleware example

### DIFF
--- a/examples/middleware/modifyResponse-middleware.js
+++ b/examples/middleware/modifyResponse-middleware.js
@@ -33,7 +33,9 @@ var util = require('util'),
 //
 // Basic Connect App
 //
-connect.createServer(
+var app = connect();
+
+app.use(
   function (req, res, next) {
     var _write = res.write;
 
@@ -41,11 +43,14 @@ connect.createServer(
       _write.call(res, data.toString().replace("Ruby", "nodejitsu"));
     }
     next();
-  },
+  }
+);
+app.use(
   function (req, res) {
     proxy.web(req, res);
   }
-).listen(8013);
+)
+app.listen(8013);
 
 //
 // Basic Http Proxy Server

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "async": "*",
     "blanket": "*",
+    "colors": "^1.1.2",
+    "connect": "^3.4.1",
     "coveralls": "*",
     "dox": "*",
     "expect.js": "*",
@@ -27,6 +29,7 @@
     "socket.io": "*",
     "socket.io-client": "*",
     "sse": "0.0.6",
+    "util": "^0.10.3",
     "ws": "^0.8.0"
   },
   "scripts": {


### PR DESCRIPTION
Hi!  I wasn't able to run the modifyResponse middleware, so I updated it.  I think the `connect` module API must have changed.  The first error I hit was `connect.createServer is not a function`.  Next, `app.use` was being passed two functions, but it can only accept one.  I also added the examples' dependencies to devDependencies so they can be run without having to manually install more deps.  Hope this helps!  Let me know if there's anything you'd like me to change.