### PR TITLE
Fix tests for node 0.10 + socket.io-client@1.4.6 (engine.io-client@1.6.9)

### DIFF
--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -419,7 +419,7 @@ describe('lib/http-proxy.js', function() {
       var destiny = io.listen(server);
 
       function startSocketIo() {
-        var client = ioClient.connect('ws://127.0.0.1:' + ports.proxy);
+        var client = ioClient.connect('ws://127.0.0.1:' + ports.proxy, {rejectUnauthorized: null});
         client.on('connect', function () {
           client.disconnect();
         });


### PR DESCRIPTION
One test "`should emit open and close events when socket.io client connects and disconnects`" is broken since socket.io-client upgraded to 1.4.6 (upgrading its dependency engine.io-client to 1.6.9), because of a new default value in commit: socketio/engine.io-client@7fa16d531b40fb316e418e8f3d9e50bb07b38531

This pull request force the value of `rejectUnauthorized` to null (like before upgrade) to fix the test.