### PR TITLE
Conserve headers' case

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -80,10 +80,26 @@ var redirectRegex = /^30(1|2|7|8)$/;
    *
    * @api private
    */
-  function writeHeaders(req, res, proxyRes) {
+  function writeHeaders(req, res, proxyRes, options) {
+    function collectHeaderNames (rawHeaders) {
+      /* Keep the capitalization of the last occurence of
+         each header. */
+      var names = {};
+      for (var i = 0; i < rawHeaders.length; i += 2) {
+        var key = rawHeaders[i].toLowerCase().trim();
+        names[key] = rawHeaders[i];
+      }
+      return names;
+    }
+
+    var names = (options.keepHeaderCase && proxyRes.rawHeaders)
+                  ? collectHeaderNames(proxyRes.rawHeaders)
+                  : {};
+
     Object.keys(proxyRes.headers).forEach(function(key) {
       if(proxyRes.headers[key] != undefined){
-        res.setHeader(String(key).trim(), proxyRes.headers[key]);
+        var trimmed = String(key).trim();
+        res.setHeader(names[trimmed] || trimmed, proxyRes.headers[key]);
       }
     });
   },

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -220,7 +220,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       headers: {}
     };
 
-    httpProxy.writeHeaders({}, res, proxyRes);
+    httpProxy.writeHeaders({}, res, proxyRes, {});
 
     expect(res.headers.hey).to.eql('hello');
     expect(res.headers.how).to.eql('are you?');


### PR DESCRIPTION
Since version [1.0.0](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_IOJS.md#http), Node has added support for getting the raw headers from an incomming message, like the ones `http.request` passes to its callback.

This opens the possibility of sending the headers to the client using the same capitalization as the target server used when responding to our request.

What the PR proposes to accomplish this goal is to add a new option, `keepHeaderCase`, that instructs the `writeHeaders` outgoing pass to build a map of lower-cased headers to its original representation located in the `rawHeaders` property of `proxyRes`.

To keep backwards compatibility with earlier versions of Node, the outgoing pass above uses the keys of the `proxyRes.headers` map as the first parameter of `res.setHeader`.

There are some corner cases regarding headers set by preceding passes; it wasn't clear to me what to do with those. But otherwise, the simple test added by the first commit in this PR works ok.

What do you think about this feature?

Thanks,
Diego
