### PR TITLE
Location header rewriting for responses with status 201

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ proxyServer.listen(8015);
 *  **localAddress**: Local interface string to bind for outgoing connections
 *  **changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL
 *  **auth**: Basic authentication i.e. 'user:password' to compute an Authorization header.
-*  **hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.
-*  **autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.
-*  **protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.
+*  **hostRewrite**: rewrites the location hostname on (201/301/302/307/308) redirects.
+*  **autoRewrite**: rewrites the location host/port on (201/301/302/307/308) redirects based on requested host/port. Default: false.
+*  **protocolRewrite**: rewrites the location protocol on (201/301/302/307/308) redirects to 'http' or 'https'. Default: null.
 *  **headers**: object with extra headers to be added to target requests.
 
 **NOTE:**

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -1,7 +1,7 @@
 var url    = require('url'),
     passes = exports;
 
-var redirectRegex = /^30(1|2|7|8)$/;
+var redirectRegex = /^201|30(1|2|7|8)$/;
 
 /*!
  * Array of passes.

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -24,7 +24,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       beforeEach(function() {
         this.options.hostRewrite = "ext-manual.com";
       });
-      [301, 302, 307, 308].forEach(function(code) {
+      [201, 301, 302, 307, 308].forEach(function(code) {
         it('on ' + code, function() {
           this.proxyRes.statusCode = code;
           httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
@@ -69,7 +69,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       beforeEach(function() {
         this.options.autoRewrite = true;
       });
-      [301, 302, 307, 308].forEach(function(code) {
+      [201, 301, 302, 307, 308].forEach(function(code) {
         it('on ' + code, function() {
           this.proxyRes.statusCode = code;
           httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
@@ -108,7 +108,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       beforeEach(function() {
         this.options.protocolRewrite = 'https';
       });
-      [301, 302, 307, 308].forEach(function(code) {
+      [201, 301, 302, 307, 308].forEach(function(code) {
         it('on ' + code, function() {
           this.proxyRes.statusCode = code;
           httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
@@ -241,4 +241,3 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
   });
 
 });
-


### PR DESCRIPTION
Implement rewriting of the location header for responses with status code 201, according to RFC2616 section 10.2.2, in response to issue #914 