### PR TITLE
close the proxy connection to avoid ECONNRESET on windows

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -78,7 +78,7 @@ web_o = Object.keys(web_o).map(function(pass) {
         (req.headers['x-forwarded-' + header] ? ',' : '') +
         values[header];
     });
-    
+
     req.headers['x-forwarded-host'] = req.headers['host'];
   },
 
@@ -160,12 +160,11 @@ web_o = Object.keys(web_o).map(function(pass) {
       // Allow us to listen when the proxy has completed
       proxyRes.on('end', function () {
         server.emit('end', req, res, proxyRes);
+        proxyReq.end();
       });
 
       proxyRes.pipe(res);
     });
-
-    //proxyReq.end();
   }
 
 ] // <--


### PR DESCRIPTION
On Windows, when simultaneous connections are proxied, some of the connections are closed with a `ECONNRESET`. This PR ensures that the connection to the remote is closed.

