### PR TITLE
Fix browserification & minification

### DIFF
--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -1,7 +1,7 @@
 var http      = require('http'),
     https     = require('https'),
     url       = require('url'),
-    httpProxy = require('./http-proxy/index.js');
+    httpProxy = require('./http-proxy/index.js'); //use explicit /index.js to help browserify negociation in require '/lib/http-proxy' (!)
 
 /**
  * Export the proxy "Server" as the main export.

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -1,7 +1,7 @@
 var http      = require('http'),
     https     = require('https'),
     url       = require('url'),
-    httpProxy = require('./http-proxy/');
+    httpProxy = require('./http-proxy/index.js');
 
 /**
  * Export the proxy "Server" as the main export.

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -1,12 +1,6 @@
-var http      = require('http'),
-    https     = require('https'),
-    url       = require('url'),
-    httpProxy = require('./http-proxy/index.js'); //use explicit /index.js to help browserify negociation in require '/lib/http-proxy' (!)
+ //use explicit /index.js to help browserify negociation in require '/lib/http-proxy' (!)
+var ProxyServer = require('./http-proxy/index.js').Server;
 
-/**
- * Export the proxy "Server" as the main export.
- */
-module.exports = httpProxy.Server;
 
 /**
  * Creates the proxy server.
@@ -23,9 +17,8 @@ module.exports = httpProxy.Server;
  * @api public
  */
 
-module.exports.createProxyServer =
-  module.exports.createServer =
-  module.exports.createProxy = function createProxyServer(options) {
+
+var createProxyServer = function(options) {
   /*
    *  `options` is needed and it must have the following layout:
    *
@@ -54,6 +47,19 @@ module.exports.createProxyServer =
    *  }
    */
 
-  return new httpProxy.Server(options);
-};
+  return new ProxyServer(options);
+}
+
+
+ProxyServer.createProxyServer = createProxyServer;
+ProxyServer.createServer      = createProxyServer;
+ProxyServer.createProxy       = createProxyServer;
+
+
+
+
+/**
+ * Export the proxy "Server" as the main export.
+ */
+module.exports = ProxyServer;
 

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -28,7 +28,7 @@ module.exports = {
    * @api private
    */
 
-  deleteLength : function(req, res, options) {
+  deleteLength : function deleteLength(req, res, options) {
     if((req.method === 'DELETE' || req.method === 'OPTIONS')
        && !req.headers['content-length']) {
       req.headers['content-length'] = '0';
@@ -46,7 +46,7 @@ module.exports = {
    * @api private
    */
 
-  timeout: function(req, res, options) {
+  timeout: function timeout(req, res, options) {
     if(options.timeout) {
       req.socket.setTimeout(options.timeout);
     }
@@ -62,7 +62,7 @@ module.exports = {
    * @api private
    */
 
-  XHeaders : function(req, res, options) {
+  XHeaders : function XHeaders(req, res, options) {
     if(!options.xfwd) return;
 
     var encrypted = req.isSpdy || common.hasEncryptedConnection(req);
@@ -94,7 +94,7 @@ module.exports = {
    * @api private
    */
 
-  stream : function(req, res, options, _, server, clb) {
+  stream : function stream(req, res, options, _, server, clb) {
 
     // And we begin!
     server.emit('start', req, res, options.target)

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -1,8 +1,7 @@
 var http   = require('http'),
     https  = require('https'),
     web_o  = require('./web-outgoing'),
-    common = require('../common'),
-    passes = exports;
+    common = require('../common');
 
 web_o = Object.keys(web_o).map(function(pass) {
   return web_o[pass];
@@ -16,7 +15,8 @@ web_o = Object.keys(web_o).map(function(pass) {
  * flexible.
  */
 
-[ // <--
+
+module.exports = {
 
   /**
    * Sets `content-length` to '0' if request is of DELETE type.
@@ -28,7 +28,7 @@ web_o = Object.keys(web_o).map(function(pass) {
    * @api private
    */
 
-  function deleteLength(req, res, options) {
+  deleteLength : function(req, res, options) {
     if((req.method === 'DELETE' || req.method === 'OPTIONS')
        && !req.headers['content-length']) {
       req.headers['content-length'] = '0';
@@ -46,7 +46,7 @@ web_o = Object.keys(web_o).map(function(pass) {
    * @api private
    */
 
-  function timeout(req, res, options) {
+  timeout: function(req, res, options) {
     if(options.timeout) {
       req.socket.setTimeout(options.timeout);
     }
@@ -62,7 +62,7 @@ web_o = Object.keys(web_o).map(function(pass) {
    * @api private
    */
 
-  function XHeaders(req, res, options) {
+  XHeaders : function(req, res, options) {
     if(!options.xfwd) return;
 
     var encrypted = req.isSpdy || common.hasEncryptedConnection(req);
@@ -94,7 +94,7 @@ web_o = Object.keys(web_o).map(function(pass) {
    * @api private
    */
 
-  function stream(req, res, options, _, server, clb) {
+  stream : function(req, res, options, _, server, clb) {
 
     // And we begin!
     server.emit('start', req, res, options.target)
@@ -168,7 +168,4 @@ web_o = Object.keys(web_o).map(function(pass) {
     //proxyReq.end();
   }
 
-] // <--
-  .forEach(function(func) {
-    passes[func.name] = func;
-  });
+};

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -23,7 +23,7 @@ module.exports = { // <--
    *
    * @api private
    */
-  removeChunked : function (req, res, proxyRes) {
+  removeChunked : function removeChunked(req, res, proxyRes) {
     if (req.httpVersion === '1.0') {
       delete proxyRes.headers['transfer-encoding'];
     }
@@ -39,7 +39,7 @@ module.exports = { // <--
    *
    * @api private
    */
-  setConnection: function(req, res, proxyRes) {
+  setConnection: function setConnection(req, res, proxyRes) {
     if (req.httpVersion === '1.0') {
       proxyRes.headers.connection = req.headers.connection || 'close';
     } else if (!proxyRes.headers.connection) {
@@ -47,7 +47,7 @@ module.exports = { // <--
     }
   },
 
-  setRedirectHostRewrite: function(req, res, proxyRes, options) {
+  setRedirectHostRewrite: function setRedirectHostRewrite(req, res, proxyRes, options) {
     if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
@@ -82,7 +82,7 @@ module.exports = { // <--
    *
    * @api private
    */
-  writeHeaders : function(req, res, proxyRes, options) {
+  writeHeaders : function writeHeaders(req, res, proxyRes, options) {
     var rewriteCookieDomainConfig = options.cookieDomainRewrite;
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
@@ -107,7 +107,7 @@ module.exports = { // <--
    *
    * @api private
    */
-  writeStatusCode : function(req, res, proxyRes) {
+  writeStatusCode : function writeStatusCode(req, res, proxyRes) {
     // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
     if(proxyRes.statusMessage) {
       res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -1,6 +1,6 @@
 var url    = require('url'),
-    common = require('../common'),
-    passes = exports;
+    common = require('../common');
+
 
 var redirectRegex = /^201|30(1|2|7|8)$/;
 
@@ -12,7 +12,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
  * flexible.
  */
 
-[ // <--
+module.exports = { // <--
 
   /**
    * If is a HTTP 1.0 request, remove chunk headers
@@ -23,7 +23,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    *
    * @api private
    */
-  function removeChunked(req, res, proxyRes) {
+  removeChunked : function (req, res, proxyRes) {
     if (req.httpVersion === '1.0') {
       delete proxyRes.headers['transfer-encoding'];
     }
@@ -39,7 +39,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    *
    * @api private
    */
-  function setConnection(req, res, proxyRes) {
+  setConnection: function(req, res, proxyRes) {
     if (req.httpVersion === '1.0') {
       proxyRes.headers.connection = req.headers.connection || 'close';
     } else if (!proxyRes.headers.connection) {
@@ -47,7 +47,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
     }
   },
 
-  function setRedirectHostRewrite(req, res, proxyRes, options) {
+  setRedirectHostRewrite: function(req, res, proxyRes, options) {
     if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
@@ -82,7 +82,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    *
    * @api private
    */
-  function writeHeaders(req, res, proxyRes, options) {
+  writeHeaders : function(req, res, proxyRes, options) {
     var rewriteCookieDomainConfig = options.cookieDomainRewrite;
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
@@ -107,7 +107,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    *
    * @api private
    */
-  function writeStatusCode(req, res, proxyRes) {
+  writeStatusCode : function(req, res, proxyRes) {
     // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
     if(proxyRes.statusMessage) {
       res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);
@@ -116,7 +116,4 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
     }
   }
 
-] // <--
-  .forEach(function(func) {
-    passes[func.name] = func;
-  });
+};

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -1,7 +1,6 @@
 var http   = require('http'),
     https  = require('https'),
-    common = require('../common'),
-    passes = exports;
+    common = require('../common');
 
 /*!
  * Array of passes.
@@ -16,9 +15,8 @@ var http   = require('http'),
  *
  */
 
-var passes = exports;
 
-[
+module.exports = {
   /**
    * WebSocket requests must have the `GET` method and
    * the `upgrade:websocket` header
@@ -29,7 +27,7 @@ var passes = exports;
    * @api private
    */
 
-  function checkMethodAndHeader (req, socket) {
+  checkMethodAndHeader : function  (req, socket) {
     if (req.method !== 'GET' || !req.headers.upgrade) {
       socket.destroy();
       return true;
@@ -51,7 +49,7 @@ var passes = exports;
    * @api private
    */
 
-  function XHeaders(req, socket, options) {
+  XHeaders : function(req, socket, options) {
     if(!options.xfwd) return;
 
     var values = {
@@ -78,7 +76,7 @@ var passes = exports;
    *
    * @api private
    */
-  function stream(req, socket, options, head, server, clb) {
+  stream : function(req, socket, options, head, server, clb) {
     common.setupSocket(socket);
 
     if (head && head.length) socket.unshift(head);
@@ -155,8 +153,4 @@ var passes = exports;
       socket.end();
     }
   }
-
-] // <--
-  .forEach(function(func) {
-    passes[func.name] = func;
-  });
+};

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -27,7 +27,7 @@ module.exports = {
    * @api private
    */
 
-  checkMethodAndHeader : function  (req, socket) {
+  checkMethodAndHeader : function checkMethodAndHeader(req, socket) {
     if (req.method !== 'GET' || !req.headers.upgrade) {
       socket.destroy();
       return true;
@@ -49,7 +49,7 @@ module.exports = {
    * @api private
    */
 
-  XHeaders : function(req, socket, options) {
+  XHeaders : function XHeaders(req, socket, options) {
     if(!options.xfwd) return;
 
     var values = {
@@ -76,7 +76,7 @@ module.exports = {
    *
    * @api private
    */
-  stream : function(req, socket, options, head, server, clb) {
+  stream : function stream(req, socket, options, head, server, clb) {
     common.setupSocket(socket);
 
     if (head && head.length) socket.unshift(head);


### PR DESCRIPTION
Browserify fails to resolve the "./http-proxy/" as "./http-proxy/index.js" but as "./http-proxy.js" (so nothing works)
Beeing explicit here does not cost much for http-proxy, yet it's intrinsically complicated for browserify to fix (as trailing slash might be used as a pollyfill shim for native/non-natives addons i.e.  require('url/') vs require('url') )