### PR TITLE
#866 Copy CA from options into outbound proxy

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -49,6 +49,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (options.auth) {
     outgoing.auth = options.auth;
   }
+  
+  if (options.ca) {
+      outgoing.ca = options.ca;
+  }
 
   if (isSSL.test(options[forward || 'target'].protocol)) {
     outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;


### PR DESCRIPTION
While using secure: true for proxy connections, there is no way to pass the trusted root CA(s) or intermediate CA(s). This change allows that to be passed in the httpProxy createServer options and used for the outgoing proxy connection.