### PR TITLE
Made it not to crash with omited Host http header

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -78,8 +78,8 @@ web_o = Object.keys(web_o).map(function(pass) {
         (req.headers['x-forwarded-' + header] ? ',' : '') +
         values[header];
     });
-    
-    req.headers['x-forwarded-host'] = req.headers['host'];
+
+    req.headers['x-forwarded-host'] = req.headers['host'] || '';
   },
 
   /**


### PR DESCRIPTION
When tools like HAProxy run health checks they don't supply http Host header,
which makes http-proxy to crash, pretty unfortunate side-effect for a health check. :)