### PR TITLE
Fix for Reason-Phrase being overwritten on proxy response.

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -108,7 +108,9 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    * @api private
    */
   function writeStatusCode(req, res, proxyRes) {
-    res.writeHead(proxyRes.statusCode);
+    res.statusCode = proxyRes.statusCode;
+    if(proxyRes.statusMessage)
+        res.statusMessage = proxyRes.statusMessage;
   }
 
 ] // <--

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -109,8 +109,9 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    */
   function writeStatusCode(req, res, proxyRes) {
     res.statusCode = proxyRes.statusCode;
-    if(proxyRes.statusMessage)
-        res.statusMessage = proxyRes.statusMessage;
+    if(proxyRes.statusMessage) {
+      res.statusMessage = proxyRes.statusMessage;
+    }
   }
 
 ] // <--


### PR DESCRIPTION
Calling res.writeHead has the side effect of setting the Reason-Phrase back to node defaults regardless of what is in the response status line.  I'm using Reason-Phrase codes to sub-route api responses and they were all being reset.  This change only sets the statusMessage (Reason-Phrase) if it exists on the proxyRes and is successfully passing it through in my tests.

from [docs](https://nodejs.org/api/http.html#http_response_statusmessage):

![image](https://cloud.githubusercontent.com/assets/424694/17754939/eab98ac6-648b-11e6-8f65-731c285f9e58.png)


So if just calling writeHead and not passing the optional statusMessage second argument, I believe it is getting reset to undefined and then defaulting it. I'm not sure if there is a good reason for using writeHead in general here since it seems like setting statusCode / statusMessage properties directly accomplishes the same with less side effects, could definitely be overlooking something.

What I see before change:
![image](https://cloud.githubusercontent.com/assets/424694/17755107/e35e1ca0-648c-11e6-928e-3a9f892b592a.png)

What I see after change:
![image](https://cloud.githubusercontent.com/assets/424694/17755121/f950b1e4-648c-11e6-872d-04091e622129.png)

