### PR TITLE
Properly write response header optionally including statusMessage

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -108,9 +108,11 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    * @api private
    */
   function writeStatusCode(req, res, proxyRes) {
-    res.statusCode = proxyRes.statusCode;
+    // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
     if(proxyRes.statusMessage) {
-      res.statusMessage = proxyRes.statusMessage;
+      res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);
+    } else {
+      res.writeHead(proxyRes.statusCode);
     }
   }
 


### PR DESCRIPTION
This re-adds the call to writeHead in [web-outgoing](/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/passes/web-outgoing.js#L110) so that other middleware which depend on or patch the response.writeHead method (such as [harmon](/No9/harmon)) don't break.

Depends on No9/harmon#38 being accepted