### PR TITLE
Add options to override the stream destination for the proxy response

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,13 @@ proxyServer.listen(8015);
      }
      ```
 *  **headers**: object with extra headers to be added to target requests.
+*  **proxyPipe**: overrides proxy response destination instead of "res" stream passed to proxyServer.web:
+   ```
+   proxyPipe: {
+     stream: "A stream object into which the proxy response will be piped",
+     options: "An optional object to pass to the options parameter in .pipe()"
+   }
+   ```
 
 **NOTE:**
 `options.ws` and `options.ssl` are optional.

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -162,7 +162,7 @@ web_o = Object.keys(web_o).map(function(pass) {
         server.emit('end', req, res, proxyRes);
       });
 
-      proxyRes.pipe(res);
+      proxyRes.pipe((options.destPipe && options.destPipe.stream) || res, (options.destPipe && options.destPipe.options) || {});
     });
 
     //proxyReq.end();

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -108,9 +108,11 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    * @api private
    */
   function writeStatusCode(req, res, proxyRes) {
-    res.statusCode = proxyRes.statusCode;
+    // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
     if(proxyRes.statusMessage) {
-      res.statusMessage = proxyRes.statusMessage;
+      res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);
+    } else {
+      res.writeHead(proxyRes.statusCode);
     }
   }
 


### PR DESCRIPTION
This adds the ability to override the stream into which the proxy response will be piped, e.g. to allow the proxy response to be piped through a transform stream before being sent back to the client.