### PR TITLE
Add options to override the stream destination for the proxy response

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -162,7 +162,7 @@ web_o = Object.keys(web_o).map(function(pass) {
         server.emit('end', req, res, proxyRes);
       });
 
-      proxyRes.pipe(res);
+      proxyRes.pipe((options.destPipe && options.destPipe.stream) || res, (options.destPipe && options.destPipe.options) || {});
     });
 
     //proxyReq.end();


### PR DESCRIPTION
This adds the ability to override the stream into which the proxy response will be piped, e.g. to allow the proxy response to be piped through a transform stream before being sent back to the client.
