### PR TITLE
Fix overwriting of global options

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -41,14 +41,15 @@ function createRightProxy(type) {
         cntr--;
       }
 
+      var requestOptions = options;
       if(
         !(args[cntr] instanceof Buffer) &&
         args[cntr] !== res
       ) {
         //Copy global options
-        options = extend({}, options);
+        requestOptions = extend({}, options);
         //Overwrite with request options
-        extend(options, args[cntr]);
+        extend(requestOptions, args[cntr]);
 
         cntr--;
       }
@@ -60,11 +61,11 @@ function createRightProxy(type) {
       /* optional args parse end */
 
       ['target', 'forward'].forEach(function(e) {
-        if (typeof options[e] === 'string')
-          options[e] = parse_url(options[e]);
+        if (typeof requestOptions[e] === 'string')
+          requestOptions[e] = parse_url(requestOptions[e]);
       });
 
-      if (!options.target && !options.forward) {
+      if (!requestOptions.target && !requestOptions.forward) {
         return this.emit('error', new Error('Must provide a proper URL as target'));
       }
 
@@ -77,7 +78,7 @@ function createRightProxy(type) {
          * refer to the connection socket
          * pass(req, socket, options, head)
          */
-        if(passes[i](req, res, options, head, this, cbl)) { // passes can return a truthy value to halt the loop
+        if(passes[i](req, res, requestOptions, head, this, cbl)) { // passes can return a truthy value to halt the loop
           break;
         }
       }

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -338,4 +338,49 @@ describe('#createProxyServer.web() using own http server', function () {
 
     http.request('http://127.0.0.1:8081', function() {}).end();
   });
+
+  it('should proxy requests to multiple servers with different options', function (done) {
+    var proxy = httpProxy.createProxyServer();
+
+    // proxies to two servers depending on url, rewriting the url as well
+    // http://127.0.0.1:8080/s1/ -> http://127.0.0.1:8081/
+    // http://127.0.0.1:8080/ -> http://127.0.0.1:8082/
+    function requestHandler(req, res) {
+      if (req.url.indexOf('/s1/') === 0) {
+        proxy.web(req, res, {
+          ignorePath: true,
+          target: 'http://127.0.0.1:8081' + req.url.substring(3)
+        });
+      } else {
+        proxy.web(req, res, {
+          target: 'http://127.0.0.1:8082'
+        });
+      }
+    }
+
+    var proxyServer = http.createServer(requestHandler);
+
+    var source1 = http.createServer(function(req, res) {
+      expect(req.method).to.eql('GET');
+      expect(req.headers.host.split(':')[1]).to.eql('8080');
+      expect(req.url).to.eql('/test1');
+    });
+
+    var source2 = http.createServer(function(req, res) {
+      source1.close();
+      source2.close();
+      proxyServer.close();
+      expect(req.method).to.eql('GET');
+      expect(req.headers.host.split(':')[1]).to.eql('8080');
+      expect(req.url).to.eql('/test2');
+      done();
+    });
+
+    proxyServer.listen('8080');
+    source1.listen('8081');
+    source2.listen('8082');
+
+    http.request('http://127.0.0.1:8080/s1/test1', function() {}).end();
+    http.request('http://127.0.0.1:8080/test2', function() {}).end();
+  });
 });


### PR DESCRIPTION
Global options are being overwritten from `proxy.web(req, res, opts)`, which breaks some more complex scenarios like proxying to multiple servers with different options.

This is essentially the same as https://github.com/nodejitsu/node-http-proxy/pull/833 but with a test case.
