### PR TITLE
Add proxy-timeout option to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ proxyServer.listen(8015);
      }
      ```
 *  **headers**: object with extra headers to be added to target requests.
+*  **proxyTimeout**: timeout (in millis) when proxy receives no response from target
 
 **NOTE:**
 `options.ws` and `options.ssl` are optional.


### PR DESCRIPTION
http-proxy provides a [proxyTimeout option](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/passes/web-incoming.js#L122) that allows us to set a timeout on the outgoing socket connection to the target. This timeout is very effective when the upstream target does not respond within an expected time.

I had wasted a few hours searching for this option. Documenting this option can save others a significant amount of time.