### PR TITLE
Revert "Properly write response header optionally including statusMessage (#1061)"

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -108,11 +108,9 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
    * @api private
    */
   function writeStatusCode(req, res, proxyRes) {
-    // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
+    res.statusCode = proxyRes.statusCode;
     if(proxyRes.statusMessage) {
-      res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);
-    } else {
-      res.writeHead(proxyRes.statusCode);
+      res.statusMessage = proxyRes.statusMessage;
     }
   }
 


### PR DESCRIPTION
I got the same issue: https://github.com/indexzero/http-server/issues/244#issuecomment-250935798

The reason is union only support `response.writeHead(statusCode, [headers])`
https://github.com/flatiron/union/blob/master/lib/response-stream.js#L72
