### PR TITLE
not setting 'connection' header in case of http2

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -42,7 +42,7 @@ var redirectRegex = /^201|30(1|2|7|8)$/;
   function setConnection(req, res, proxyRes) {
     if (req.httpVersion === '1.0') {
       proxyRes.headers.connection = req.headers.connection || 'close';
-    } else if (!proxyRes.headers.connection) {
+    } else if (req.httpVersion !== '2.0' && !proxyRes.headers.connection) {
       proxyRes.headers.connection = req.headers.connection || 'keep-alive';
     }
   },

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -191,6 +191,28 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       expect(proxyRes.headers.connection).to.eql('keep-alive');
     });
 
+    it('don`t set connection with 2.0 if exist', function() {
+      var proxyRes = { headers: {} };
+      httpProxy.setConnection({
+        httpVersion: '2.0',
+        headers: {
+          connection: 'namstey'
+        }
+      }, {}, proxyRes);
+
+      expect(proxyRes.headers.connection).to.eql(undefined);
+    });
+
+    it('don`t set connection with 2.0 if doesn`t exist', function() {
+      var proxyRes = { headers: {} };
+      httpProxy.setConnection({
+        httpVersion: '2.0',
+        headers: {}
+      }, {}, proxyRes);
+
+      expect(proxyRes.headers.connection).to.eql(undefined);
+    })
+
   });
 
   describe('#writeStatusCode', function () {


### PR DESCRIPTION
when using with 'http2', http2 throws an error 'can't set deprecated header : connection'