### PR TITLE
Keep original letter case of response header keys

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -83,32 +83,32 @@ module.exports = { // <--
    * @api private
    */
   writeHeaders: function writeHeaders(req, res, proxyRes, options) {
-    var rewriteCookieDomainConfig = options.cookieDomainRewrite;
+    var rewriteCookieDomainConfig = options.cookieDomainRewrite,
+        setHeader = function(key, header) {
+          if (header != undefined) {
+            if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
+              header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+            }
+            res.setHeader(String(key).trim(), header);
+          }
+        };
+
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
     }
+
     // message.rawHeaders is added in: v0.11.6
     // https://nodejs.org/api/http.html#http_message_rawheaders
     if (proxyRes.rawHeaders != undefined) {
       for (var i = 0; i < proxyRes.rawHeaders.length; i += 2) {
         var key = proxyRes.rawHeaders[i];
         var header = proxyRes.rawHeaders[i + 1];
-        if (header != undefined) {
-          if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
-            header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
-          }
-          res.setHeader(String(key).trim(), header);
-        }
+        setHeader(key, header);
       };
     } else {
       Object.keys(proxyRes.headers).forEach(function(key) {
         var header = proxyRes.headers[key];
-        if (header != undefined) {
-          if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
-            header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
-          }
-          res.setHeader(String(key).trim(), header);
-        }
+        setHeader(key, header);
       });
     }
   },

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -87,15 +87,16 @@ module.exports = { // <--
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
     }
-    Object.keys(proxyRes.headers).forEach(function(key) {
-      var header = proxyRes.headers[key];
+    for (var i = 0; i < proxyRes.rawHeaders.length; i += 2) {
+      var key = proxyRes.rawHeaders[i];
+      var header = proxyRes.rawHeaders[i + 1];
       if (header != undefined) {
         if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
           header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
         }
         res.setHeader(String(key).trim(), header);
       }
-    });
+    };
   },
 
   /**

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -87,16 +87,30 @@ module.exports = { // <--
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
     }
-    for (var i = 0; i < proxyRes.rawHeaders.length; i += 2) {
-      var key = proxyRes.rawHeaders[i];
-      var header = proxyRes.rawHeaders[i + 1];
-      if (header != undefined) {
-        if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
-          header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+    // message.rawHeaders is added in: v0.11.6
+    // https://nodejs.org/api/http.html#http_message_rawheaders
+    if (proxyRes.rawHeaders != undefined) {
+      for (var i = 0; i < proxyRes.rawHeaders.length; i += 2) {
+        var key = proxyRes.rawHeaders[i];
+        var header = proxyRes.rawHeaders[i + 1];
+        if (header != undefined) {
+          if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
+            header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+          }
+          res.setHeader(String(key).trim(), header);
         }
-        res.setHeader(String(key).trim(), header);
-      }
-    };
+      };
+    } else {
+      Object.keys(proxyRes.headers).forEach(function(key) {
+        var header = proxyRes.headers[key];
+        if (header != undefined) {
+          if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
+            header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+          }
+          res.setHeader(String(key).trim(), header);
+        }
+      });
+    }
   },
 
   /**

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -234,11 +234,18 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
           hey: 'hello',
           how: 'are you?',
           'set-cookie': 'hello; domain=my.domain; path=/'
-        }
+        },
+        rawHeaders: [
+          'Hey', 'hello',
+          'How', 'are you?',
+          'Set-Cookie', 'hello; domain=my.domain; path=/'
+        ]
       };
       this.res = {
         setHeader: function(k, v) {
-          this.headers[k] = v;
+          // https://nodejs.org/api/http.html#http_message_headers
+          // Header names are lower-cased
+          this.headers[k.toLowerCase()] = v;
         },
         headers: {}
       };
@@ -260,7 +267,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
 
       expect(this.res.headers['set-cookie']).to.eql('hello; domain=my.domain; path=/');
     });
-    
+
     it('rewrites domain', function() {
       var options = {
         cookieDomainRewrite: 'my.new.domain'
@@ -290,6 +297,12 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
         }
       };
       this.proxyRes.headers['set-cookie'] = [
+        'hello-on-my.domain; domain=my.domain; path=/',
+        'hello-on-my.old.domain; domain=my.old.domain; path=/',
+        'hello-on-my.special.domain; domain=my.special.domain; path=/'
+      ];
+      var setCookieValueIndex = this.proxyRes.rawHeaders.indexOf('Set-Cookie') + 1;
+      this.proxyRes.rawHeaders[setCookieValueIndex] = [
         'hello-on-my.domain; domain=my.domain; path=/',
         'hello-on-my.old.domain; domain=my.old.domain; path=/',
         'hello-on-my.special.domain; domain=my.special.domain; path=/'

--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -148,6 +148,9 @@ describe('lib/http-proxy.js', function() {
         method: 'GET'
       }, function(res) {
         expect(res.statusCode).to.eql(200);
+        expect(res.headers['content-type']).to.eql('text/plain');
+        expect(res.rawHeaders.indexOf('Content-Type')).not.to.eql(-1);
+        expect(res.rawHeaders.indexOf('text/plain')).not.to.eql(-1);
 
         res.on('data', function (data) {
           expect(data.toString()).to.eql('Hello from ' + ports.source);

--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -149,8 +149,10 @@ describe('lib/http-proxy.js', function() {
       }, function(res) {
         expect(res.statusCode).to.eql(200);
         expect(res.headers['content-type']).to.eql('text/plain');
-        expect(res.rawHeaders.indexOf('Content-Type')).not.to.eql(-1);
-        expect(res.rawHeaders.indexOf('text/plain')).not.to.eql(-1);
+        if (res.rawHeaders != undefined) {
+          expect(res.rawHeaders.indexOf('Content-Type')).not.to.eql(-1);
+          expect(res.rawHeaders.indexOf('text/plain')).not.to.eql(-1);
+        }
 
         res.on('data', function (data) {
           expect(data.toString()).to.eql('Hello from ' + ports.source);


### PR DESCRIPTION
This PR fixes the issue https://github.com/nodejitsu/node-http-proxy/issues/1029

In RFC, HTTP header key is case-insensitive (ref: https://github.com/nodejs/node-v0.x-archive/issues/1954).
But, proxy server should care not to change the original request unintentionally ✨ 