### PR TITLE
Handle errors for forward request

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -103,6 +103,10 @@ module.exports = {
       var forwardReq = (options.forward.protocol === 'https:' ? https : http).request(
         common.setupOutgoing(options.ssl || {}, options, req, 'forward')
       );
+
+      // error handler (e.g. ECONNREFUSED)
+      forwardReq.on('error', proxyError);
+
       (options.buffer || req).pipe(forwardReq);
       if(!options.target) { return res.end(); }
     }
@@ -138,7 +142,7 @@ module.exports = {
 
     function proxyError (err){
       if (req.socket.destroyed && err.code === 'ECONNRESET') {
-        server.emit('econnreset', err, req, res, options.target);
+        server.emit('econnreset', err, req, res, options.target || options.forward);
         return proxyReq.abort();
       }
 


### PR DESCRIPTION
Errors in forward requests were not handled. This caused my process to exit after an `ECONNREFUSED`.

Errors in target request and the original request were already properly handled. I added forward request error handling the same way.

Added a test case proving the fix.