### PR TITLE
Fix newly introduced error in handler for forward ECONNREFUSED

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -97,15 +97,19 @@ module.exports = {
   stream: function stream(req, res, options, _, server, clb) {
 
     // And we begin!
-    server.emit('start', req, res, options.target)
+    server.emit('start', req, res, options.target || options.forward);
+
     if(options.forward) {
       // If forward enable, so just pipe the request
       var forwardReq = (options.forward.protocol === 'https:' ? https : http).request(
         common.setupOutgoing(options.ssl || {}, options, req, 'forward')
       );
 
-      // error handler (e.g. ECONNREFUSED)
-      forwardReq.on('error', proxyError);
+      // error handler (e.g. ECONNRESET, ECONNREFUSED)
+      // Handle errors on incoming request as well as it makes sense to
+      var forwardError = createErrorHandler(forwardReq, options.forward);
+      req.on('error', forwardError);
+      forwardReq.on('error', forwardError);
 
       (options.buffer || req).pipe(forwardReq);
       if(!options.target) { return res.end(); }
@@ -134,22 +138,23 @@ module.exports = {
       proxyReq.abort();
     });
 
-    // Handle errors on incoming request as well as it makes sense to
+    // handle errors in proxy and incoming request, just like for forward proxy
+    var proxyError = createErrorHandler(proxyReq, options.target);
     req.on('error', proxyError);
-
-    // Error Handler
     proxyReq.on('error', proxyError);
 
-    function proxyError (err){
-      if (req.socket.destroyed && err.code === 'ECONNRESET') {
-        server.emit('econnreset', err, req, res, options.target || options.forward);
-        return proxyReq.abort();
-      }
+    function createErrorHandler(proxyReq, url) {
+      return function proxyError(err) {
+        if (req.socket.destroyed && err.code === 'ECONNRESET') {
+          server.emit('econnreset', err, req, res, url);
+          return proxyReq.abort();
+        }
 
-      if (clb) {
-        clb(err, req, res, options.target);
-      } else {
-        server.emit('error', err, req, res, options.target);
+        if (clb) {
+          clb(err, req, res, url);
+        } else {
+          server.emit('error', err, req, res, url);
+        }
       }
     }
 


### PR DESCRIPTION
In my merged PR #1099, I was too fast. I didn't make enough changes in the error handler and for `ECONNREFUSED` this introduced a new error, since `proxyReq` was not defined.

To fix it, I wrapped the error handler in a `createErrorHandler()` function to specify which request should be handled (`proxyReq` or `forwardReq`).