### PR TITLE
Enable proxy response to have multiple Set-Cookie raw headers #1101

### DIFF
--- a/examples/http/proxy-https-to-http.js
+++ b/examples/http/proxy-https-to-http.js
@@ -39,7 +39,7 @@ var https = require('https'),
 http.createServer(function (req, res) {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('hello http over https\n');
-	res.end();
+  res.end();
 }).listen(9009);
 
 //

--- a/examples/http/proxy-https-to-https.js
+++ b/examples/http/proxy-https-to-https.js
@@ -43,7 +43,7 @@ var https = require('https'),
 https.createServer(httpsOpts, function (req, res) {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.write('hello https\n');
-	res.end();
+  res.end();
 }).listen(9010);
 
 //

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -84,12 +84,19 @@ module.exports = { // <--
    */
   writeHeaders: function writeHeaders(req, res, proxyRes, options) {
     var rewriteCookieDomainConfig = options.cookieDomainRewrite,
+        // In proxyRes.rawHeaders Set-Cookie headers are sparse.
+        // so, we'll collect Set-Cookie headers, and set them in the response as an array.
+        set_cookies = [],
         setHeader = function(key, header) {
           if (header != undefined) {
-            if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
-              header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+            if (key === 'Set-Cookie' || key === 'set-cookie') {
+              if (rewriteCookieDomainConfig) {
+                header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+              }
+              set_cookies.push(header); // defer
+            } else {
+              res.setHeader(String(key).trim(), header);
             }
-            res.setHeader(String(key).trim(), header);
           }
         };
 
@@ -99,17 +106,20 @@ module.exports = { // <--
 
     // message.rawHeaders is added in: v0.11.6
     // https://nodejs.org/api/http.html#http_message_rawheaders
-    if (proxyRes.rawHeaders != undefined) {
+    if (proxyRes.rawHeaders !== undefined) {
       for (var i = 0; i < proxyRes.rawHeaders.length; i += 2) {
         var key = proxyRes.rawHeaders[i];
         var header = proxyRes.rawHeaders[i + 1];
         setHeader(key, header);
-      };
+      }
     } else {
       Object.keys(proxyRes.headers).forEach(function(key) {
         var header = proxyRes.headers[key];
         setHeader(key, header);
       });
+    }
+    if (set_cookies.length) {
+      res.setHeader('Set-Cookie', set_cookies.length === 1 ? set_cookies[0] : set_cookies);
     }
   },
 

--- a/test/lib-https-proxy-test.js
+++ b/test/lib-https-proxy-test.js
@@ -19,7 +19,7 @@ Object.defineProperty(gen, 'port', {
 
 describe('lib/http-proxy.js', function() {
   describe('HTTPS #createProxyServer', function() {
-  	describe('HTTPS to HTTP', function () {
+    describe('HTTPS to HTTP', function () {
       it('should proxy the request en send back the response', function (done) {
         var ports = { source: gen.port, proxy: gen.port };
         var source = http.createServer(function(req, res) {


### PR DESCRIPTION
Implementation of proxy HTTP raw headers response processing in 1.16.0 fails to account for multiple `Set-Cookie` headers.  This patch accounts for multiple Set-Cookie header, and sets the source response headers to an array.