### PR TITLE
Update eventemitter3 to version 2.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "eventemitter3": "1.x.x",
+    "eventemitter3": "2.0.x",
     "requires-port": "1.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
`node-http-proxy` is not affected by the only breaking change in version [2.0.0](https://github.com/primus/eventemitter3/releases/tag/2.0.0) so I think it makes sense to update as there are some nice performance improvements.