### PR TITLE
Improved formatting for some lines in README.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ Logo created by [Diego Pasquali](http://dribbble.com/diegopq)
 
 ### Contributing and Issues
 
+* Read carefully our [Code Of Conduct](https://github.com/nodejitsu/node-http-proxy/blob/master/CODE_OF_CONDUCT.md)
+
 * Search on Google/Github
 * If you can't find anything, open an issue
 * If you feel comfortable about fixing the issue, fork the repo

--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
   <img src="https://raw.github.com/nodejitsu/node-http-proxy/master/doc/logo.png"/>
 </p>
 
-node-http-proxy
+# node-http-proxy
 =======
 
 <p align="left">
  <a href="https://travis-ci.org/nodejitsu/node-http-proxy" target="_blank">
-  <img src="https://travis-ci.org/nodejitsu/node-http-proxy.png"/></a>&nbsp;&nbsp;
+  <img src="https://travis-ci.org/nodejitsu/node-http-proxy.png"/>
+ </a>
+ &nbsp;&nbsp;
  <a href="https://coveralls.io/r/nodejitsu/node-http-proxy" target="_blank">
-  <img src="https://coveralls.io/repos/nodejitsu/node-http-proxy/badge.png"/></a>
+  <img src="https://coveralls.io/repos/nodejitsu/node-http-proxy/badge.png"/>
+ </a>
 </p>
 
-`node-http-proxy` is an HTTP programmable proxying library that supports
+**node-http-proxy** is an HTTP programmable proxying library that supports
 websockets. It is suitable for implementing components such as reverse
 proxies and load balancers.
 
@@ -60,7 +63,7 @@ var httpProxy = require('http-proxy');
 
 var proxy = httpProxy.createProxyServer(options); // See (†)
 ```
-†Unless listen(..) is invoked on the object, this does not create a webserver. See below.
+*Unless listen(port) method is invoked within the object, ``createProxyServer`` does not create a webserver. See below.*
 
 An object will be returned with four methods:
 
@@ -120,7 +123,7 @@ http.createServer(function (req, res) {
   res.end();
 }).listen(9000);
 ```
-†Invoking listen(..) triggers the creation of a web server. Otherwise, just the proxy instance is created.
+*Invoking listen(port) method triggers the creation of a web server. Otherwise, just the proxy instance is created.*
 
 **[Back to top](#table-of-contents)**
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "eventemitter3": "1.x.x",
+    "eventemitter3": "2.0.x",
     "requires-port": "1.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Corresponding to the explanations preceded by the '†' symbol. I had to re-read those lines when reading the doc, I think makes more reading-sense now.

Please review. Does not change the README itself.