### PR TITLE
location header rewriting for HTTP 303

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,9 @@ proxyServer.listen(8015);
 *  **changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL
 *  **preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key
 *  **auth**: Basic authentication i.e. 'user:password' to compute an Authorization header.
-*  **hostRewrite**: rewrites the location hostname on (201/301/302/307/308) redirects.
-*  **autoRewrite**: rewrites the location host/port on (201/301/302/307/308) redirects based on requested host/port. Default: false.
-*  **protocolRewrite**: rewrites the location protocol on (201/301/302/307/308) redirects to 'http' or 'https'. Default: null.
+*  **hostRewrite**: rewrites the location hostname on (201/301/302/303/307/308) redirects.
+*  **autoRewrite**: rewrites the location host/port on (201/301/302/303/307/308) redirects based on requested host/port. Default: false.
+*  **protocolRewrite**: rewrites the location protocol on (201/301/302/303/307/308) redirects to 'http' or 'https'. Default: null.
 *  **cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:
    * `false` (default): disable cookie rewriting
    * String: new domain, for example `cookieDomainRewrite: "new.domain"`. To remove the domain, use `cookieDomainRewrite: ""`.

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -2,7 +2,7 @@ var url    = require('url'),
     common = require('../common');
 
 
-var redirectRegex = /^201|30(1|2|7|8)$/;
+var redirectRegex = /^201|30(1|2|3|7|8)$/;
 
 /*!
  * Array of passes.

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -24,7 +24,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       beforeEach(function() {
         this.options.hostRewrite = 'ext-manual.com';
       });
-      [201, 301, 302, 307, 308].forEach(function(code) {
+      [201, 301, 302, 303, 307, 308].forEach(function(code) {
         it('on ' + code, function() {
           this.proxyRes.statusCode = code;
           httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
@@ -69,7 +69,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       beforeEach(function() {
         this.options.autoRewrite = true;
       });
-      [201, 301, 302, 307, 308].forEach(function(code) {
+      [201, 301, 302, 303, 307, 308].forEach(function(code) {
         it('on ' + code, function() {
           this.proxyRes.statusCode = code;
           httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);
@@ -108,7 +108,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       beforeEach(function() {
         this.options.protocolRewrite = 'https';
       });
-      [201, 301, 302, 307, 308].forEach(function(code) {
+      [201, 301, 302, 303, 307, 308].forEach(function(code) {
         it('on ' + code, function() {
           this.proxyRes.statusCode = code;
           httpProxy.setRedirectHostRewrite(this.req, {}, this.proxyRes, this.options);


### PR DESCRIPTION
resolves #845

This PR enables hostRewrite, autoRewrite, and protocolRewrite on HTTP 303 (See Other) redirects.