### PR TITLE
bugfix: use upstream proxy

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -50,7 +50,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (options.auth) {
     outgoing.auth = options.auth;
   }
-  
+
   if (options.ca) {
       outgoing.ca = options.ca;
   }
@@ -103,6 +103,25 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
         ? outgoing.host + ':' + outgoing.port
         : outgoing.host;
   }
+
+  if (options.toProxy) {
+    var upstreamProxyServer;
+    if (typeof options.toProxy === 'boolean') {
+      url.parse(
+        isSSL.test(options[forward || 'target'].protocol) ? process.env['https_proxy'] || '' : process.env['http_proxy'] || ''
+      );
+    } else {
+      url.parse(options.toProxy);
+    }
+    
+    if (upstreamProxyServer) {
+      outgoing.path = options[forward || 'target'].protocol + '//' + outgoing.host + outgoing.path;
+      outgoing.host = upstreamProxyServer.host;
+      outgoing.hostname = upstreamProxyServer.hostname;
+      outgoing.port = upstreamProxyServer.port;
+    }
+  }
+
   return outgoing;
 };
 


### PR DESCRIPTION
Handle toProxy option properly and get proxy settings from environment.

There is an option toProxy (true/false) for http-proxy. But it is never used afaiks.
This fix checks the option and uses the http/https proxy set in the environment variables.

Usage:
```
{
  "/api": {
    "target": "http://upstreamserver.net",
    "toProxy": true
  }
}
```

Sorry, for I had no time for unit tests (just needed a local hotfix ;) )... If you like the solution I could into this PR in more detail during the weekend.

