### PR TITLE
Update options.changeOrigin description in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ proxyServer.listen(8015);
 *  **prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path
 *  **ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).
 *  **localAddress**: Local interface string to bind for outgoing connections
-*  **changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL
+*  **changeOrigin**: true/false, Default: false - changes host header to match the target URL
 *  **preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key
 *  **auth**: Basic authentication i.e. 'user:password' to compute an Authorization header.
 *  **hostRewrite**: rewrites the location hostname on (201/301/302/307/308) redirects.


### PR DESCRIPTION
changeOrigin has nothing to do with `origin` header which is confusing and harmful when working with CORS. As CORS middleware sometimes makes decisions depending on `origin` header.

`changeOrigin` option handles solely `host` header.