### PR TITLE
support sending servername in proxied request

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -36,7 +36,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
                   (isSSL.test(options[forward || 'target'].protocol) ? 443 : 80);
 
   ['host', 'hostname', 'socketPath', 'pfx', 'key',
-    'passphrase', 'cert', 'ca', 'ciphers', 'secureProtocol'].forEach(
+    'passphrase', 'cert', 'ca', 'ciphers', 'secureProtocol', 'servername'].forEach(
     function(e) { outgoing[e] = options[forward || 'target'][e]; }
   );
 
@@ -58,7 +58,6 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (isSSL.test(options[forward || 'target'].protocol)) {
     outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;
   }
-
 
   outgoing.agent = options.agent || false;
   outgoing.localAddress = options.localAddress;

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -330,7 +330,8 @@ describe('lib/http-proxy/common.js', function () {
           cert: 'my-cert',
           ca: 'my-ca',
           ciphers: 'my-ciphers',
-          secureProtocol: 'my-secure-protocol'
+          secureProtocol: 'my-secure-protocol',
+          servername: 'my-servername',
         }
       },
       {
@@ -345,6 +346,7 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.ca).eql('my-ca');
       expect(outgoing.ciphers).eql('my-ciphers');
       expect(outgoing.secureProtocol).eql('my-secure-protocol');
+      expect(outgoing.servername).eql('my-servername');
     });
 
     // url.parse('').path => null


### PR DESCRIPTION
This provides support for sending along a `servername` with encrypted requests. It should address #1133. 