### PR TITLE
Add headers duplications preservation

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ proxyServer.listen(8015);
 *  **localAddress**: Local interface string to bind for outgoing connections
 *  **changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL
 *  **preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key
+*  **preserveHeaderDuplications**: true/false, Default: false - specify whether you want to keep response headers duplication
 *  **auth**: Basic authentication i.e. 'user:password' to compute an Authorization header.
 *  **hostRewrite**: rewrites the location hostname on (201/301/302/307/308) redirects.
 *  **autoRewrite**: rewrites the location host/port on (201/301/302/307/308) redirects based on requested host/port. Default: false.

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -35,7 +35,8 @@ function createProxyServer(options) {
    *    ignorePath: <true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request>
    *    localAddress : <Local interface string to bind for outgoing connections>
    *    changeOrigin: <true/false, Default: false - changes the origin of the host header to the target URL>
-   *    preserveHeaderKeyCase: <true/false, Default: false - specify whether you want to keep letter case of response header key >
+   *    preserveHeaderKeyCase: <true/false, Default: false - specify whether you want to keep response headers duplication >
+   *    preserveHeaderDuplications: <true/false, Default: false - specify whether you want to keep letter case of response header key >
    *    auth   : Basic authentication i.e. 'user:password' to compute an Authorization header.
    *    hostRewrite: rewrites the location hostname on (301/302/307/308) redirects, Default: null.
    *    autoRewrite: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -83,7 +83,9 @@ module.exports = { // <--
    * @api private
    */
   writeHeaders: function writeHeaders(req, res, proxyRes, options) {
-    var rewriteCookieDomainConfig = options.cookieDomainRewrite,
+    var i,
+        rawHeaderMap,
+        rewriteCookieDomainConfig = options.cookieDomainRewrite,
         preserveHeaderKeyCase = options.preserveHeaderKeyCase,
         preserveHeaderDuplications = options.preserveHeaderDuplications,
         setHeader = function(key, header) {
@@ -99,18 +101,17 @@ module.exports = { // <--
     }
 
     if ((preserveHeaderKeyCase || preserveHeaderDuplications) && proxyRes.rawHeaders != undefined) {
-      var j;
-      var rawHeaderMap = {};
+      rawHeaderMap = {};
 
-      for (j = 0; j < proxyRes.rawHeaders.length; j += 2) {
-        var name = proxyRes.rawHeaders[j];
+      for (i = 0; i < proxyRes.rawHeaders.length; i += 2) {
+        var name = proxyRes.rawHeaders[i];
         var nameL = name.toLowerCase();
 
         if (!rawHeaderMap[nameL]) {
           rawHeaderMap[nameL] = {name: name, value: []};
         }
 
-        rawHeaderMap[nameL].value.push(proxyRes.rawHeaders[j + 1]);
+        rawHeaderMap[nameL].value.push(proxyRes.rawHeaders[i + 1]);
       }
     }
 
@@ -120,8 +121,8 @@ module.exports = { // <--
     var key;
     var header;
 
-    for (j = 0; j < keys.length; j++) {
-      key = keys[j];
+    for (i = 0; i < keys.length; i++) {
+      key = keys[i];
 
       if (preserveHeaderDuplications && rawHeaderMap && rawHeaderMap[key]) {
         header = rawHeaderMap[key].value || proxyRes.headers[key];

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -85,7 +85,7 @@ module.exports = { // <--
   writeHeaders: function writeHeaders(req, res, proxyRes, options) {
     var rewriteCookieDomainConfig = options.cookieDomainRewrite,
         preserveHeaderKeyCase = options.preserveHeaderKeyCase,
-        rawHeaderKeyMap,
+        preserveHeaderDuplications = options.preserveHeaderDuplications,
         setHeader = function(key, header) {
           if (header == undefined) return;
           if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
@@ -98,23 +98,43 @@ module.exports = { // <--
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
     }
 
-    // message.rawHeaders is added in: v0.11.6
-    // https://nodejs.org/api/http.html#http_message_rawheaders
-    if (preserveHeaderKeyCase && proxyRes.rawHeaders != undefined) {
-      rawHeaderKeyMap = {};
-      for (var i = 0; i < proxyRes.rawHeaders.length; i += 2) {
-        var key = proxyRes.rawHeaders[i];
-        rawHeaderKeyMap[key.toLowerCase()] = key;
+    if ((preserveHeaderKeyCase || preserveHeaderDuplications) && proxyRes.rawHeaders != undefined) {
+      var j;
+      var rawHeaderMap = {};
+
+      for (j = 0; j < proxyRes.rawHeaders.length; j += 2) {
+        var name = proxyRes.rawHeaders[j];
+        var nameL = name.toLowerCase();
+
+        if (!rawHeaderMap[nameL]) {
+          rawHeaderMap[nameL] = {name: name, value: []};
+        }
+
+        rawHeaderMap[nameL].value.push(proxyRes.rawHeaders[j + 1]);
       }
     }
 
-    Object.keys(proxyRes.headers).forEach(function(key) {
-      var header = proxyRes.headers[key];
-      if (preserveHeaderKeyCase && rawHeaderKeyMap) {
-        key = rawHeaderKeyMap[key] || key;
+
+    // Code optimization: https://jsperf.com/object-keys-vs-for-in-with-closure/137
+    var keys = Object.keys(proxyRes.headers);
+    var key;
+    var header;
+
+    for (j = 0; j < keys.length; j++) {
+      key = keys[j];
+
+      if (preserveHeaderDuplications && rawHeaderMap && rawHeaderMap[key]) {
+        header = rawHeaderMap[key].value || proxyRes.headers[key];
+      } else {
+        header = proxyRes.headers[key];
       }
+
+      if (preserveHeaderKeyCase && rawHeaderMap && rawHeaderMap[key]) {
+        key = rawHeaderMap[key].name || key;
+      }
+
       setHeader(key, header);
-    });
+    }
   },
 
   /**


### PR DESCRIPTION
Hello, I needed the server repsonse headers to not be touched by node js so I've added a missing option "preserveHeaderDuplications".