### PR TITLE
Simplify outgoing path computation when there is no merging of paths

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -95,7 +95,14 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   //
   outgoingPath = !options.ignorePath ? outgoingPath : '';
 
-  outgoing.path = common.urlJoin(targetPath, outgoingPath);
+
+  if (!targetPath) {
+    outgoing.path = outgoingPath;
+  } else if (!outgoingPath) {
+    outgoing.path = targetPath;
+  } else {
+    outgoing.path = common.urlJoin(targetPath, outgoingPath);
+  }
 
   if (options.changeOrigin) {
     outgoing.headers.host =

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -275,6 +275,17 @@ describe('lib/http-proxy/common.js', function () {
         expect(outgoing.path).to.eql('/some/crazy/path/whoooo');
       });
 
+      it('should ignore the path of the `req.url` passed in but use the target path', function () {
+        var outgoing = {};
+        var myEndpoint = 'https://whatever.com/some/crazy/path/whoooo?hello=1&hello=https://2.a.a&ola=https://a.c.c';
+        common.setupOutgoing(outgoing, {
+          target: url.parse(myEndpoint),
+          ignorePath: true
+        }, { url: '/more/crazy/pathness' });
+
+        expect(outgoing.path).to.eql('/some/crazy/path/whoooo?hello=1&hello=https://2.a.a&ola=https://a.c.c');
+      });
+
       it('and prependPath: false, it should ignore path of target and incoming request', function () {
          var outgoing = {};
         var myEndpoint = 'https://whatever.com/some/crazy/path/whoooo';


### PR DESCRIPTION
Simplify outgoing path path computation when one of the two paths is empty.