### PR TITLE
Store the request object in proxy errors

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -104,6 +104,7 @@ module.exports = {
       var forwardReq = (options.forward.protocol === 'https:' ? https : http).request(
         common.setupOutgoing(options.ssl || {}, options, req, 'forward')
       );
+      forwardReq.proxyRequestType = 'forward';
 
       // error handler (e.g. ECONNRESET, ECONNREFUSED)
       // Handle errors on incoming request as well as it makes sense to
@@ -119,6 +120,7 @@ module.exports = {
     var proxyReq = (options.target.protocol === 'https:' ? https : http).request(
       common.setupOutgoing(options.ssl || {}, options, req)
     );
+    proxyReq.proxyRequestType = 'target';
 
     // Enable developers to modify the proxyReq before headers are sent
     proxyReq.on('socket', function(socket) {
@@ -145,6 +147,8 @@ module.exports = {
 
     function createErrorHandler(proxyReq, url) {
       return function proxyError(err) {
+        err.request = proxyReq;
+
         if (req.socket.destroyed && err.code === 'ECONNRESET') {
           server.emit('econnreset', err, req, res, url);
           return proxyReq.abort();

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -225,6 +225,10 @@ describe('#createProxyServer.web() using own http server', function () {
         expect(errRes).to.be.equal(res);
         expect(new Date().getTime() - started).to.be.greaterThan(99);
         expect(err.code).to.be('ECONNRESET');
+        expect(err.request).to.be.an(Object);
+        expect(err.request.proxyRequestType).to.be('target');
+        expect(err.request._headers.host).to.be('127.0.0.1:8084');
+        expect(err.request.path).to.be('/');
         done();
       });
 
@@ -264,6 +268,10 @@ describe('#createProxyServer.web() using own http server', function () {
         expect(errReq).to.be.equal(req);
         expect(errRes).to.be.equal(res);
         expect(err.code).to.be('ECONNRESET');
+        expect(err.request).to.be.an(Object);
+        expect(err.request.proxyRequestType).to.be('target');
+        expect(err.request._headers.host).to.be('127.0.0.1:8085');
+        expect(err.request.path).to.be('/');
         doneOne();
       });
 


### PR DESCRIPTION
This would allow someone to differentiate between client errors and
target server errors in their proxy error handling, by inspecting the
error request property.

I'm not sure if this is how you'd prefer to do this, open to alternatives.
The problem I'm trying to solve is in a proxy service I maintain – I'd
like to differentiate between client and server errors in our logging.

This is a potential solution for #1017. E.g:

```js
proxy.on('error', (error, request, response, url) => {
    // Will log either "target" or "forward"
    console.log(`Error came from ${error.request.proxyRequestType}`);
});
```