### PR TITLE
use .hostname instead of .host in comparison

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -55,7 +55,7 @@ module.exports = { // <--
       var u = url.parse(proxyRes.headers['location']);
 
       // make sure the redirected host matches the target host before rewriting
-      if (target.host != u.host) {
+      if (target.hostname != u.hostname) {
         return;
       }
 


### PR DESCRIPTION
.hostname does not include port number, .host does
It becomes an issue when proxying to port 80, which is being ommited in one part of comparison (e.g it becomes 'env.host.com` != 'env.host.com:80')