### PR TITLE
issue #953: stop using writeHead

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -129,9 +129,10 @@ module.exports = { // <--
   writeStatusCode: function writeStatusCode(req, res, proxyRes) {
     // From Node.js docs: response.writeHead(statusCode[, statusMessage][, headers])
     if(proxyRes.statusMessage) {
-      res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);
+      res.statusCode = proxyRes.statusCode;
+      res.statusMessage = proxyRes.statusMessage;
     } else {
-      res.writeHead(proxyRes.statusCode);
+      res.statusCode = proxyRes.statusCode;
     }
   }
 


### PR DESCRIPTION
Using object.keys in web-incoming.js results in a non-deterministic ordering of keys, which means that in web-outgoing writeHead might be called before setHeader, which throws an error.

Example of a server that fails to send a response : 
```
const http = require('http');

const server = http.createServer((req, res) => {
  res.writeHead(200);
  res.setHeader('Content-Type', 'text/html');
  res.setHeader('X-Foo', 'bar');
  res.end('ok');
});

server.listen(3000);
```
This will throw `Error: Can't set headers after they are sent.` when a request is made to it. If we change it to the following, it will work:

```
const http = require('http');

const server = http.createServer((req, res) => {
  res.statusCode = 200;
  // res.writeHead(200);
  res.setHeader('Content-Type', 'text/html');
  res.setHeader('X-Foo', 'bar');
  res.end('ok');
});

server.listen(3000);
```