### PR TITLE
Include websocket non-upgrade response

### DIFF
--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -415,7 +415,6 @@ describe('lib/http-proxy.js', function() {
 
       client.on('error', function (err) {
         expect(err).to.be.an(Error);
-        expect(err.code).to.be('ECONNRESET');
         proxyServer.close();
         done();
       });


### PR DESCRIPTION
When the server do not accept the upgrade request for websockets the
response was previously not included and sent back. Now the proxy will
include the headers and the content from the server and the response in
these cases. Fixes #890.