### PR TITLE
FEAT: Bindings section allows for per host name forward / target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ proxyServer.listen(8015);
      ```
 *  **headers**: object with extra headers to be added to target requests.
 *  **proxyTimeout**: timeout (in millis) when proxy receives no response from target
+*  **binding**: object allowing for per hostname targeting / forwarding. Each object key specifies hostname glob. When the glob is matched, the options listed under the key are used by the proxy. To merge the base option config with a partial, domain glob specific configuration, specify _merge: true at the partial config root. Intended to be used with a single (port, protocol) proxy and star certificate in case SSL is needed.
 
 **NOTE:**
 `options.ws` and `options.ssl` are optional.

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -5,9 +5,43 @@ var httpProxy = module.exports,
     http      = require('http'),
     https     = require('https'),
     web       = require('./passes/web-incoming'),
-    ws        = require('./passes/ws-incoming');
+    ws        = require('./passes/ws-incoming'),
+    minimatch = require('minimatch');
+
 
 httpProxy.Server = ProxyServer;
+
+function compileBindCondition( glob ) {
+  return [ glob, minimatch.makeRe( glob ) ];
+}
+
+function prepareHostOptionsGet( opt ) {
+  
+  var options = extend({}, opt);
+  var binding = options.binding || { };
+  var bindCondition = Object.keys( binding ).map( compileBindCondition );
+
+  delete options.binding;
+
+  return function( host ) {
+    var b, r = options;
+    for ( var i = 0, it, l = bindCondition.length; i < l; i ++ ) {
+      if ( ( it = bindCondition[ i ] )[ 1 ].test( host ) ) {
+        b = binding[ it[ 0 ] ];
+        break;
+      }
+    }
+    if ( b ) {
+      r = extend(
+            ( b._merge ? 
+                extend( { }, options ) : { } ),
+            b );
+      delete r._merge;
+    }
+    return r;
+  }
+  
+}
 
 /**
  * Returns a function that creates the loader for
@@ -27,8 +61,14 @@ httpProxy.Server = ProxyServer;
 
 function createRightProxy(type) {
 
-  return function(options) {
+  return function( opt ) {
+    
+    var getHostOptions = prepareHostOptionsGet( opt );
+
     return function(req, res /*, [head], [opts] */) {
+
+      var options = getHostOptions( ( ( req && req.headers ) || {} ).host );
+
       var passes = (type === 'ws') ? this.wsPasses : this.webPasses,
           args = [].slice.call(arguments),
           cntr = args.length - 1,

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -101,7 +101,7 @@ module.exports = {
 
     if(options.forward) {
       // If forward enable, so just pipe the request
-      var forwardReq = (options.forward.protocol === 'https:' ? https : http).request(
+      var forwardReq = (common.isSSL.test( options.forward.protocol ) ? https : http).request(
         common.setupOutgoing(options.ssl || {}, options, req, 'forward')
       );
 
@@ -116,7 +116,7 @@ module.exports = {
     }
 
     // Request initalization
-    var proxyReq = (options.target.protocol === 'https:' ? https : http).request(
+    var proxyReq = (common.isSSL.test( options.target.protocol ) ? https : http).request(
       common.setupOutgoing(options.ssl || {}, options, req)
     );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-proxy",
-  "version": "1.16.2",
+  "version": "1.18.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/nodejitsu/node-http-proxy.git"
@@ -13,6 +13,7 @@
   "main": "index.js",
   "dependencies": {
     "eventemitter3": "2.0.x",
+    "minimatch": "^3.0.3",
     "requires-port": "1.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Single proxy may handle requests targeting multiple "hosts"/ DNS entries and then distribute the load as per the caller specified host. Both target host and target port are part of the load distribution.

For instance, consider the following distribution spec:

```
var binding = {
    "yarn.pronto.peerbelt.com": {
        target: "https://yarnpkg.com:443",
        "changeOrigin": true
    },
    "google.pronto.peerbelt.com": {
        target: "https://www.google.com:443",
        "changeOrigin": true
    },
    "*.pronto.peerbelt.com": {
        target: "https://www.microsoft.com:443/en-us/",
        "changeOrigin": true
    },
    "pronto.peerbelt.com": {
        target: {
            host: "overlayads.herokuapp.com",
            port: 443,
            protocol: "https"
        },
        changeOrigin: true
    }
};
```

Based on it, HTTP request targeting:
* ```yarn.pronto.peerbelt.com``` are getting forwarded to ```https://yarnpkg.com:443```
* ```pronto.peerbelt.com``` calls ```overlayads.herokuapp.com```
* ```something-different.pronto.peerbelt.com``` follows the wildcard rule hitting ```https://www.microsoft.com:443/en-us/``` accordingly

Anything not found in the distribution spec follows the already existing proxy rules. For instance:

```
httpProxy.createServer({
  binding: binding,
  target: {
    host: "localhost",
    port: 3030
  }
}).listen(80)
.on( "error", socketErrorHandler );
```

with incoming request targeting ```my.peerbelt.com``` is simply forwarded to ```localhost:3030```.

## Todos
- [ ] Tests
