### PR TITLE
Add use case for proxy to HTTPS using a PKCS12 client certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,24 @@ httpProxy.createServer({
 }).listen(443);
 ```
 
+##### HTTP -> HTTPS (using a PKCS12 client certificate)
+
+```js
+//
+// Create an HTTP proxy server with an HTTPS target
+//
+httpProxy.createProxyServer({
+  target: {
+    protocol: 'https:',
+    host: 'my-domain-name',
+    port: 443,
+    pfx: fs.readFileSync('path/to/certificate.p12'),
+    passphrase: 'password',
+  },
+  changeOrigin: true,
+}).listen(8000);
+```
+
 **[Back to top](#table-of-contents)**
 
 #### Proxying WebSockets


### PR DESCRIPTION
Add an example under the [Using HTTPS](https://github.com/nodejitsu/node-http-proxy#using-https) section on how to proxy requests to an HTTPS server that requires a PKCS12 client certificate (like the one you normally import in your browser).

I recently had this exact use case and while looking for a solution I stumbled upon Issues #826 and #1090 (which helped me in finding a solution).

Browsing the changes of Pull Request #590, I saw that you can pass extra parameters in the `target` object.