### PR TITLE
Added timeout option to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ proxyServer.listen(8015);
      }
      ```
 *  **headers**: object with extra headers to be added to target requests.
-*  **proxyTimeout**: timeout (in millis) when proxy receives no response from target
+*  **proxyTimeout**: timeout (in millis) for outgoing proxy requests
+*  **timeout**: timeout (in millis) for incoming requests
 
 **NOTE:**
 `options.ws` and `options.ssl` are optional.


### PR DESCRIPTION
Hi, it seems that `timeout` option is missing in the docs ([code reference here](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/passes/web-incoming.js#L39-L53)). This would be a useful addition because I wasted several hours trying to figure out what was wrong, until I happened to find this option from the library source code.

Thanks!