### PR TITLE
Add option to rewrite path in set-cookie headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,18 @@ proxyServer.listen(8015);
        "*": ""
      }
      ```
+*  **cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:
+   * `false` (default): disable cookie rewriting
+   * String: new path, for example `cookiePathRewrite: "/newPath/"`. To remove the path, use `cookiePathRewrite: ""`. To set path to root use `cookiePathRewrite: "/"`.
+   * Object: mapping of paths to new paths, use `"*"` to match all paths.  
+     For example keep one path unchanged, rewrite one path and remove other paths:
+     ```
+     cookiePathRewrite: {
+       "/unchanged.path/": "/unchanged.path/",
+       "/old.path/": "/new.path/",
+       "*": ""
+     }
+     ```
 *  **headers**: object with extra headers to be added to target requests.
 *  **proxyTimeout**: timeout (in millis) when proxy receives no response from target
 

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -5,7 +5,7 @@ var common   = exports,
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
     isSSL = /^https|wss/,
-    cookieDomainRegex = /(;\s*domain=)([^;]+)/i;
+    cookieProps = ['domain', 'path'];
 
 /**
  * Simple Regex for testing if protocol is https
@@ -211,27 +211,30 @@ common.urlJoin = function() {
  *
  * @api private
  */
-common.rewriteCookieDomain = function rewriteCookieDomain(header, config) {
+common.rewriteCookieProperty = function rewriteCookieProperty(header, config, property) {
+  if(cookieProps.indexOf(property) === -1) //Property not supported
+    return header;
+
   if (Array.isArray(header)) {
     return header.map(function (headerElement) {
-      return rewriteCookieDomain(headerElement, config);
+      return rewriteCookieProperty(headerElement, config, property);
     });
   }
-  return header.replace(cookieDomainRegex, function(match, prefix, previousDomain) {
-    var newDomain;
-    if (previousDomain in config) {
-      newDomain = config[previousDomain];
+  return header.replace(new RegExp("(;\\s*" + property + "=)([^;]+)"), function(match, prefix, previousValue) {
+    var newValue;
+    if (previousValue in config) {
+      newValue = config[previousValue];
     } else if ('*' in config) {
-      newDomain = config['*'];
+      newValue = config['*'];
     } else {
-      //no match, return previous domain
+      //no match, return previous value
       return match;
     }
-    if (newDomain) {
-      //replace domain
-      return prefix + newDomain;
+    if (newValue) {
+      //replace value
+      return prefix + newValue;
     } else {
-      //remove domain
+      //remove value
       return '';
     }
   });

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -220,7 +220,7 @@ common.rewriteCookieProperty = function rewriteCookieProperty(header, config, pr
       return rewriteCookieProperty(headerElement, config, property);
     });
   }
-  return header.replace(new RegExp("(;\\s*" + property + "=)([^;]+)"), function(match, prefix, previousValue) {
+  return header.replace(new RegExp("(;\\s*" + property + "=)([^;]+)", 'i'), function(match, prefix, previousValue) {
     var newValue;
     if (previousValue in config) {
       newValue = config[previousValue];

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -4,8 +4,7 @@ var common   = exports,
     required = require('requires-port');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
-    isSSL = /^https|wss/,
-    cookieProps = ['domain', 'path'];
+    isSSL = /^https|wss/;
 
 /**
  * Simple Regex for testing if protocol is https
@@ -212,9 +211,6 @@ common.urlJoin = function() {
  * @api private
  */
 common.rewriteCookieProperty = function rewriteCookieProperty(header, config, property) {
-  if(cookieProps.indexOf(property) === -1) //Property not supported
-    return header;
-
   if (Array.isArray(header)) {
     return header.map(function (headerElement) {
       return rewriteCookieProperty(headerElement, config, property);

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -84,18 +84,26 @@ module.exports = { // <--
    */
   writeHeaders: function writeHeaders(req, res, proxyRes, options) {
     var rewriteCookieDomainConfig = options.cookieDomainRewrite,
+        rewriteCookiePathConfig = options.cookiePathRewrite,
         preserveHeaderKeyCase = options.preserveHeaderKeyCase,
         rawHeaderKeyMap,
         setHeader = function(key, header) {
           if (header == undefined) return;
           if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
-            header = common.rewriteCookieDomain(header, rewriteCookieDomainConfig);
+            header = common.rewriteCookieProperty(header, rewriteCookieDomainConfig, 'domain');
+          }
+          if (rewriteCookiePathConfig && key.toLowerCase() === 'set-cookie') {
+            header = common.rewriteCookieProperty(header, rewriteCookiePathConfig, 'path');
           }
           res.setHeader(String(key).trim(), header);
         };
 
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''
       rewriteCookieDomainConfig = { '*': rewriteCookieDomainConfig };
+    }
+
+    if (typeof rewriteCookiePathConfig === 'string') { //also test for ''
+      rewriteCookiePathConfig = { '*': rewriteCookiePathConfig };
     }
 
     // message.rawHeaders is added in: v0.11.6

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -298,6 +298,17 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
         .to.contain('hello; domain=my.domain; path=/');
     });
 
+    it('rewrites path', function() {
+      var options = {
+        cookiePathRewrite: '/dummyPath'
+      };
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie'])
+        .to.contain('hello; domain=my.domain; path=/dummyPath');
+    });
+
     it('rewrites domain', function() {
       var options = {
         cookieDomainRewrite: 'my.new.domain'

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -289,15 +289,6 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       expect(this.res.headers['set-cookie']).to.have.length(2);
     });
 
-    it('does not rewrite domain', function() {
-      var options = {};
-
-      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
-
-      expect(this.res.headers['set-cookie'])
-        .to.contain('hello; domain=my.domain; path=/');
-    });
-
     it('rewrites path', function() {
       var options = {
         cookiePathRewrite: '/dummyPath'
@@ -307,6 +298,35 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
 
       expect(this.res.headers['set-cookie'])
         .to.contain('hello; domain=my.domain; path=/dummyPath');
+    });
+
+    it('does not rewrite path', function() {
+      var options = {};
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie'])
+        .to.contain('hello; domain=my.domain; path=/');
+    });
+
+    it('removes path', function() {
+      var options = {
+        cookiePathRewrite: ''
+      };
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie'])
+        .to.contain('hello; domain=my.domain');
+    });
+
+    it('does not rewrite domain', function() {
+      var options = {};
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie'])
+        .to.contain('hello; domain=my.domain; path=/');
     });
 
     it('rewrites domain', function() {


### PR DESCRIPTION
Adding ability to rewrite the path of a cookie in the set-cookie header, building on top of what was there for https://github.com/nodejitsu/node-http-proxy/pull/1009. I added some documentation and test cases and am open to feedback. I look forward to having this merged in.

Example usage:
`"cookiePathRewrite": "/"`

This will rewrite cookie paths from `/dummyPath` to `/`. This is useful when using Tomcat and each application is hosted in it's own "context" (which is the war file name), so the path for each cookie is set to the war file name.