### PR TITLE
Test initialPort (1024) collision on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tes.js
 npm-debug.log
 .nyc_output
 coverage
+.sonarlint

--- a/test/lib-http-proxy-test.js
+++ b/test/lib-http-proxy-test.js
@@ -11,7 +11,7 @@ var httpProxy = require('../lib/http-proxy'),
 // Expose a port number generator.
 // thanks to @3rd-Eden
 //
-var initialPort = 1024, gen = {};
+var initialPort = 11024, gen = {};
 Object.defineProperty(gen, 'port', {
   get: function get() {
     return initialPort++;

--- a/test/lib-https-proxy-test.js
+++ b/test/lib-https-proxy-test.js
@@ -10,7 +10,7 @@ var httpProxy = require('../lib/http-proxy'),
 // Expose a port number generator.
 // thanks to @3rd-Eden
 //
-var initialPort = 1024, gen = {};
+var initialPort = 11024, gen = {};
 Object.defineProperty(gen, 'port', {
   get: function get() {
     return initialPort++;


### PR DESCRIPTION
The new port is 11024.

There are several failing test without it.