### PR TITLE
Fix out sync documentation in http-proxy.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Click [here](UPGRADING.md)
 ### Core Concept
 
 A new proxy is created by calling `createProxyServer` and passing
-an `options` object as argument ([valid properties are available here](lib/http-proxy.js#L22-L50))
+an `options` object as argument ([valid properties are available here](#options))
 
 ```javascript
 var httpProxy = require('http-proxy');

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -40,6 +40,51 @@ function createProxyServer(options) {
    *    hostRewrite: rewrites the location hostname on (301/302/307/308) redirects, Default: null.
    *    autoRewrite: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.
    *    protocolRewrite: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.
+   *    cookieDomainRewrite: rewrites domain of set-cookie headers. Default: false. Possible values:
+   *        * false: disable cookie rewriting
+   *        * String: new domain, for example cookieDomainRewrite: "new.domain". To remove the domain, use cookieDomainRewrite: "".
+   *        * Object: mapping of domains to new domains, use "*" to match all domains. For example keep one domain unchanged, rewrite one domain and remove other domains:
+   *          ```
+   *           cookieDomainRewrite: {
+   *             "unchanged.domain": "unchanged.domain",
+   *             "old.domain": "new.domain",
+   *             "*": ""
+   *           }
+   *           ```
+   *     cookiePathRewrite: rewrites path of set-cookie headers. Default: false. Possible values:
+   *        * false: disable cookie rewriting
+   *        * String: new path, for example cookiePathRewrite: "/newPath/". To remove the path, use cookiePathRewrite: "". To set path to root use cookiePathRewrite: "/".
+   *        * Object: mapping of paths to new paths, use "*" to match all paths. For example, to keep one path unchanged, rewrite one path and remove other paths:
+   *          ```
+   *          cookiePathRewrite: {
+   *            "/unchanged.path/": "/unchanged.path/",
+   *            "/old.path/": "/new.path/",
+   *            "*": ""
+   *          }
+   *          ```
+   *     headers: object with extra headers to be added to target requests.
+   *     proxyTimeout: timeout (in millis) for outgoing proxy requests
+   *     timeout: timeout (in millis) for incoming requests
+   *     followRedirects: true/false, Default: false - specify whether you want to follow redirects
+   *     selfHandleResponse true/false, if set to true, none of the webOutgoing passes are called and it’s your responsibility to appropriately return the response by listening and acting on the proxyRes event
+   *     buffer: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on. 
+   *        If you read the body of a request into a field called ‘req.rawbody’ you could restream this field in the buffer option:
+   *        ```
+   *        'use strict';
+   *
+   *        const streamify = require('stream-array');
+   *        const HttpProxy = require('http-proxy');
+   *        const proxy = new HttpProxy();
+   *
+   *        module.exports = (req, res, next) => {
+   *
+   *          proxy.web(req, res, {
+   *            target: 'http://localhost:4003/',
+   *            buffer: streamify(req.rawBody)
+   *          }, next);
+   *
+   *        };
+   *        ```
    *  }
    *
    *  NOTE: `options.ws` and `options.ssl` are optional.


### PR DESCRIPTION
I found that the proxy server options readme point to http-proxy.js which the documentation has not been updated.

