### PR TITLE
Disable the 2 minutes default incoming timeout by default, matches proxyTimeout defaut behavior

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -50,9 +50,8 @@ module.exports = {
    */
 
   timeout: function timeout(req, res, options) {
-    if(options.timeout) {
-      req.socket.setTimeout(options.timeout);
-    }
+    var timeoutValue = (options.timeout ? options.timeout : 0);
+    req.socket.setTimeout(timeoutValue);
   },
 
   /**


### PR DESCRIPTION
Hi

   This modification will save head hakes to those playing with long HTTP request.

   Thanks!

   Johny

DESCRIPTION:
Now, if the incoming timeout option is not set or if set to 0, it will be disabled by setting the req.socket timeout to 0.
This replace the default node.js 2 minutes timeout and now support disabling it.

It will have the same default behavior than the incoming proxyTimeout option.

TEST:
In a Windows and Arm-Linux environment, set option.timeout to 0, to 5 minutes and no timeout option.
Run a 8 minutes long request. Confirm expected behavior for all cases.