### PR TITLE
Detect and trim any invalid incoming req header name

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -126,14 +126,14 @@ module.exports = {
     // Without trimming it will crash server
     var reqHeaderKeys = Object.keys(req.headers);
     for (var i = 0; i < reqHeaderKeys.length; i++) {
-        var reqHeaderKey = reqHeaderKeys[i];
-        if (reqHeaderKey.includes(" ")) {
-            var trimmedKey = reqHeaderKey.trim();
-            // Add new trimmed header to req headers
-            req.headers[trimmedKey] = req.headers[reqHeaderKey];
-            // Remove invalid header
-            delete req.headers[reqHeaderKey];
-        }
+      var reqHeaderKey = reqHeaderKeys[i];
+      if (reqHeaderKey.includes(" ")) {
+        var trimmedKey = reqHeaderKey.trim();
+        // Add new trimmed header to req headers
+        req.headers[trimmedKey] = req.headers[reqHeaderKey];
+        // Remove invalid header
+        delete req.headers[reqHeaderKey];
+      }
     }
 
     // Request initalization

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -122,6 +122,20 @@ module.exports = {
       if(!options.target) { return res.end(); }
     }
 
+    // Check incoming req headers if they contain whitespace and trim if true.
+    // Without trimming it will crash server
+    var reqHeaderKeys = Object.keys(req.headers);
+    for (var i = 0; i < reqHeaderKeys.length; i++) {
+        var reqHeaderKey = reqHeaderKeys[i];
+        if (reqHeaderKey.includes(" ")) {
+            var trimmedKey = reqHeaderKey.trim();
+            // Add new trimmed header to req headers
+            req.headers[trimmedKey] = req.headers[reqHeaderKey];
+            // Remove invalid header
+            delete req.headers[reqHeaderKey];
+        }
+    }
+
     // Request initalization
     var proxyReq = (options.target.protocol === 'https:' ? https : http).request(
       common.setupOutgoing(options.ssl || {}, options, req)


### PR DESCRIPTION
Issue #1261
In web-incoming.js it is not handled if incoming req header name start or end with whitespace.
Result is crashing of application. Issue is easy to reproduce by manually adding in req headers header with whitespace (example 'cookie '). In production issue is observed on node 4.8.0 and http-proxy 1.16.2 version. Application is build in Meteor which does not handle this as well.
Submitted solution is to loop through req headers and when invalid header is detected, add new header with trimmed name and remove existing invalid header.
Fix verified on node 4.8.0 and all tests passed.