### PR TITLE
Pass options to proxyRes event.

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,7 +1,8 @@
 var common   = exports,
     url      = require('url'),
     extend   = require('util')._extend,
-    required = require('requires-port');
+    required = require('requires-port'),
+    web_o    = require('./passes/web-outgoing');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
     isSSL = /^https|wss/;
@@ -234,6 +235,26 @@ common.rewriteCookieProperty = function rewriteCookieProperty(header, config, pr
       return '';
     }
   });
+};
+
+const webOPasses = Object.keys(web_o).map(function(pass) {
+  return web_o[pass];
+});
+
+/**
+ * Runs the "web-outgoing" functions.
+ *
+ * @param {ClientRequest} Req Request object
+ * @param {IncomingMessage} Res Response object
+ * @param {proxyResponse} Res Response object from the proxy request
+ * @param {Object} Options options.cookieDomainRewrite: Config to rewrite cookie domain
+ *
+ * @api private
+ */
+common.runWebOutgoingPasses = function runWebOutgoingPasses(req, res, proxyRes, options) {
+  for (var i=0; i < webOPasses.length; i++) {
+    if (webOPasses[i](req, res, proxyRes, options)) { break; }
+  }
 };
 
 /**

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -1,12 +1,7 @@
 var httpNative   = require('http'),
     httpsNative  = require('https'),
-    web_o  = require('./web-outgoing'),
     common = require('../common'),
     followRedirects = require('follow-redirects');
-
-web_o = Object.keys(web_o).map(function(pass) {
-  return web_o[pass];
-});
 
 var nativeAgents = { http: httpNative, https: httpsNative };
 
@@ -168,12 +163,10 @@ module.exports = {
     (options.buffer || req).pipe(proxyReq);
 
     proxyReq.on('response', function(proxyRes) {
-      if(server) { server.emit('proxyRes', proxyRes, req, res); }
+      if(server) { server.emit('proxyRes', proxyRes, req, res, options); }
 
       if(!res.headersSent && !options.selfHandleResponse) {
-        for(var i=0; i < web_o.length; i++) {
-          if(web_o[i](req, res, proxyRes, options)) { break; }
-        }
+        common.runWebOutgoingPasses(req, res, proxyRes, options);
       }
 
       if (!res.finished) {

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -325,8 +325,9 @@ describe('#createProxyServer.web() using own http server', function () {
     });
 
     function requestHandler(req, res) {
-      proxy.once('proxyRes', function (proxyRes, pReq, pRes) {
+      proxy.once('proxyRes', function (proxyRes, pReq, pRes, options) {
         proxyRes.pipe(concat(function (body) {
+          expect(options.selfHandleResponse).to.equal(true);
           expect(body.toString('utf8')).eql('Response');
           pRes.end(Buffer.from('my-custom-response'));
         }))


### PR DESCRIPTION
I wanted to be able to use the built-in web-outgoing passes for including default headers into my final response.  Only thing is that options weren't available in it.  This fixes it.

I also moved the web outgoing passes function into common for code-reuse.