### PR TITLE
Add support for non-standard URLs

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -49,7 +49,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (options.auth) {
     outgoing.auth = options.auth;
   }
-  
+
   if (options.ca) {
       outgoing.ca = options.ca;
   }
@@ -94,7 +94,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   //
   outgoingPath = !options.ignorePath ? outgoingPath : '';
 
-  outgoing.path = common.urlJoin(targetPath, outgoingPath);
+  outgoing.path = outgoingPath ? common.urlJoin(targetPath, outgoingPath) : targetPath;
 
   if (options.changeOrigin) {
     outgoing.headers.host =


### PR DESCRIPTION
Our business has URLs like `/node/sso/esi?&url=https%3A//redacted.banno.com/redacted/`

This is obviously non-standard.

Running the URL through `common.urlJoin` messes it up unnecessarily.

This should be a safe change to avoid the "no-op" when `outgoingPath` is an empty string (making the call to `common.urlJoin` useless as far as I can tell)