### PR TITLE
Fix example of PKCS12 cert use

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,10 @@ httpProxy.createProxyServer({
     protocol: 'https:',
     host: 'my-domain-name',
     port: 443,
-    pfx: fs.readFileSync('path/to/certificate.p12'),
-    passphrase: 'password',
+    ssl: {
+      pfx: fs.readFileSync('path/to/certificate.p12'),
+      passphrase: 'password',
+    },
   },
   changeOrigin: true,
 }).listen(8000);


### PR DESCRIPTION
The `pfx` and `passphrase` args should be passed inside the `ssl` option, just like in the previous PEM examples.