### PR TITLE
Fix option.target can't contains question mark

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -197,8 +197,9 @@ common.urlJoin = function() {
 
   // Handle case where there could be multiple ? in the URL.
   retSegs.push.apply(retSegs, lastSegs);
+  var sp = retSegs[0].indexOf('?') > -1 ? '&' : '?'
 
-  return retSegs.join('?')
+  return retSegs.join(sp)
 };
 
 /**


### PR DESCRIPTION
fix case target: `http://www.example.com?project=.example&path=`,and  incoming requrest with query _t=123456