### PR TITLE
add request source to error handler

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -114,9 +114,9 @@ module.exports = {
 
       // error handler (e.g. ECONNRESET, ECONNREFUSED)
       // Handle errors on incoming request as well as it makes sense to
-      var forwardError = createErrorHandler(forwardReq, options.forward);
-      req.on('error', forwardError);
-      forwardReq.on('error', forwardError);
+      var forwardError = (reqSource) => createErrorHandler(forwardReq, options.forward, reqSource);
+      req.on('error', forwardError('client'));
+      forwardReq.on('error', forwardError('target'));
 
       (options.buffer || req).pipe(forwardReq);
       if(!options.target) { return res.end(); }
@@ -146,21 +146,22 @@ module.exports = {
     });
 
     // handle errors in proxy and incoming request, just like for forward proxy
-    var proxyError = createErrorHandler(proxyReq, options.target);
-    req.on('error', proxyError);
-    proxyReq.on('error', proxyError);
+    var proxyError = (reqSource) => createErrorHandler(proxyReq, options.target, reqSource);
+      
+    req.on('error', proxyError('client'));
+    proxyReq.on('error', proxyError('target'));
 
-    function createErrorHandler(proxyReq, url) {
+    function createErrorHandler(proxyReq, url, reqSource) {
       return function proxyError(err) {
-        if (req.socket.destroyed && err.code === 'ECONNRESET') {
+        if (req.socket.destroyed && err.code === 'ECONNRESET' && reqSource === 'client') {
           server.emit('econnreset', err, req, res, url);
           return proxyReq.abort();
         }
 
         if (clb) {
-          clb(err, req, res, url);
+          clb(err, req, res, url, reqSource);
         } else {
-          server.emit('error', err, req, res, url);
+          server.emit('error', err, req, res, url, reqSource);
         }
       }
     }


### PR DESCRIPTION
this allows to see if it's a client error or a backend error. the error handler has next to the target url a new paramter called request source which is either "client" or "target".