### PR TITLE
FIX: Don't break on invalid headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "8"
-  - "10"
+  - '8'
+  - '10'
+  - '12'
 script:
   - npm test
 after_success:

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -95,7 +95,11 @@ module.exports = { // <--
           if (rewriteCookiePathConfig && key.toLowerCase() === 'set-cookie') {
             header = common.rewriteCookieProperty(header, rewriteCookiePathConfig, 'path');
           }
-          res.setHeader(String(key).trim(), header);
+          try {
+            res.setHeader(String(key).trim(), header);
+          } catch(error) {
+            console.warn(error, key, header);
+          }
         };
 
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "version": "auto-changelog -p && git add CHANGELOG.md"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT"
 }

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -289,6 +289,26 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
       expect(this.res.headers['set-cookie']).to.have.length(2);
     });
 
+    it('skips invalid headers', function() {
+      var options = {};
+      var invalidRawHeaders = [
+        ...this.rawProxyRes.rawHeaders,
+        'Set-Cookie', 'invalid\\u0001header; domain=my.domain; path=/'
+      ];
+      var invalidRawProxyRes = { 
+        ...this.rawProxyRes, 
+        rawHeaders: invalidRawHeaders 
+      };
+      httpProxy.writeHeaders({}, this.res, invalidRawProxyRes, options);
+
+      expect(this.res.headers.hey).to.eql('hello');
+      expect(this.res.headers.how).to.eql('are you?');
+
+      expect(this.res.headers).to.have.key('set-cookie');
+      expect(this.res.headers['set-cookie']).to.be.an(Array);
+      expect(this.res.headers['set-cookie']).to.have.length(2);
+    });
+
     it('rewrites path', function() {
       var options = {
         cookiePathRewrite: '/dummyPath'

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -291,15 +291,10 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
 
     it('skips invalid headers', function() {
       var options = {};
-      var invalidRawHeaders = [
-        ...this.rawProxyRes.rawHeaders,
+      this.rawProxyRes.rawHeaders = this.rawProxyRes.rawHeaders.concat([
         'Set-Cookie', 'invalid\\u0001header; domain=my.domain; path=/'
-      ];
-      var invalidRawProxyRes = { 
-        ...this.rawProxyRes, 
-        rawHeaders: invalidRawHeaders 
-      };
-      httpProxy.writeHeaders({}, this.res, invalidRawProxyRes, options);
+      ])
+      httpProxy.writeHeaders({}, this.res, this.rawProxyRes, options);
 
       expect(this.res.headers.hey).to.eql('hello');
       expect(this.res.headers.how).to.eql('are you?');


### PR DESCRIPTION
Have found that in some scenarios the proxied server does return invalid characters in the headers, like here:
https://github.com/nodejs/node/issues/21509

In the current version the proxy does break when a invalid character is found with a
`[ERR_INVALID_CHAR]: Invalid character in header content`

This PR aims to avoid the total crash of the application and instead show a warning in the console and process all what can be processed.