### PR TITLE
Fix to use 'abort' event instead of 'aborted' property

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -143,7 +143,7 @@ module.exports = {
     }
 
     // Ensure we abort proxy if request is aborted
-    req.on('aborted', function () {
+    req.on('abort', function () {
       proxyReq.abort();
     });
 

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -331,7 +331,7 @@ describe('#createProxyServer.web() using own http server', function () {
       expect(new Date().getTime() - started).to.be.greaterThan(99);
       doneOne();
     });
-    req.end();
+    req.abort();
   });
 
   it('should proxy the request and provide a proxyRes event with the request and response parameters', function(done) {

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -331,7 +331,7 @@ describe('#createProxyServer.web() using own http server', function () {
       expect(new Date().getTime() - started).to.be.greaterThan(99);
       doneOne();
     });
-    req.abort();
+    req.end();
   });
 
   it('should proxy the request and provide a proxyRes event with the request and response parameters', function(done) {


### PR DESCRIPTION
Fixes https://github.com/http-party/node-http-proxy/issues/1455