### PR TITLE
replace all http:/ with http:// bug fix

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -188,8 +188,8 @@ common.urlJoin = function() {
   retSegs = [
     args.filter(Boolean).join('/')
         .replace(/\/+/g, '/')
-        .replace('http:/', 'http://')
-        .replace('https:/', 'https://')
+        .replace(/http:\//g, 'http://')
+        .replace(/https:\//g, 'https://')
   ];
 
   // Only join the query string if it exists so we don't have trailing a '?'

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -227,6 +227,15 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.path).to.eql('/forward/?foo=bar//&target=http://foobar.com/?a=1%26b=2&other=2');
     })
 
+    it('should replace multiple http:/ with http://', function () {
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {
+        target: { path: '/' },
+      }, { url: '/xyz/http://foobar.com/http://foobar.com/https://foobar.com' });
+
+      expect(outgoing.path).to.eql('/xyz/http://foobar.com/http://foobar.com/https://foobar.com');
+    })
+
     //
     // This is the proper failing test case for the common.join problem
     //


### PR DESCRIPTION
Test case added to help understand the issue

```
it('should replace multiple http:/ with http://', function () {
      var outgoing = {};
      common.setupOutgoing(outgoing, {
        target: { path: '/' },
      }, { url: '/xyz/http://foobar.com/http://foobar.com/https://foobar.com' });

      expect(outgoing.path).to.eql('/xyz/http://foobar.com/http://foobar.com/https://foobar.com');
    })
```