### PR TITLE
feat: when get a chunked response, flush headers

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -142,6 +142,21 @@ module.exports = { // <--
     } else {
       res.statusCode = proxyRes.statusCode;
     }
-  }
+  },
 
+  /**
+   * If is a chunked response, flush headers.
+   * 
+   * @param {ClientRequest} Req Request object
+   * @param {IncomingMessage} Res Response object
+   * @param {proxyResponse} Res Response object from the proxy request
+   * 
+   * @api private
+   */
+  chunkedResponse: function chunkedResponse(req, res, proxyRes){
+    let te = proxyRes.headers['transfer-encoding']
+    if (te && te.toLowerCase() == 'chunked') {
+      res.flushHeaders()
+    }
+  },
 };

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -420,4 +420,22 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
     expect(proxyRes.headers['transfer-encoding']).to.eql(undefined);
   });
 
+  describe('#chunkedHeader', function(){
+    var proxyRes = {
+      headers: {
+        'transfer-encoding': 'chunked'
+      }
+    };
+    var b = false
+    var res = {
+      flushHeaders: () => {
+        b = true
+      }
+    }
+
+    httpProxy.chunkedResponse({}, res, proxyRes)
+
+    expect(b).to.eql(true)
+  })
+
 });


### PR DESCRIPTION
if proxy a chunked response. when server return http-header but don't response body immediately. http-proxy will blocked until server body sent.