### PR TITLE
do not pipe req into proxyReq until socket is connected

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -129,6 +129,15 @@ module.exports = {
 
     // Enable developers to modify the proxyReq before headers are sent
     proxyReq.on('socket', function(socket) {
+      if (socket.pending) {
+        // if not connected, wait till connect to pipe
+        socket.on ('connect', () => (options.buffer || req).pipe(proxyReq));
+      }
+      else {
+        // socket is connected (reused?), just pipe
+        (options.buffer || req).pipe(proxyReq);
+      }
+
       if(server && !proxyReq.getHeader('expect')) {
         server.emit('proxyReq', proxyReq, req, res, options);
       }
@@ -166,8 +175,6 @@ module.exports = {
         }
       }
     }
-
-    (options.buffer || req).pipe(proxyReq);
 
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }


### PR DESCRIPTION
While building a reverse proxy with ha-lb capabilities I found out that proxy.web() does not play totally well with retries if a request body is present: it turns out the original req is piped into the proxyReq immediately, even before the socket at proxyReq tries to connect; such piping would read some (or even all) of the original req's body even if the socket does not connect; those body bytes would be lost if we choose to proxy.web() the same request onto an alternative target

The patch delays the piping until proxyReq's socket is present, and it's either connected (that is, reused from an agent) or suceeds to connect