### PR TITLE
Update ntlm-authentication.js

### DIFF
--- a/examples/http/ntlm-authentication.js
+++ b/examples/http/ntlm-authentication.js
@@ -1,13 +1,18 @@
-var httpProxy = require('../../lib/http-proxy');
-var Agent = require('agentkeepalive');
+var httpProxy = require('http-proxy');
+var http = require('http');
 
-var agent =  new Agent({
-  maxSockets: 100,
-  keepAlive: true,
-  maxFreeSockets: 10,
-  keepAliveMsecs:1000,
-  timeout: 60000,
-  keepAliveTimeout: 30000 // free socket keepalive for 30 seconds
+class customAgent extends http.Agent {
+    getName(options) {
+        return options.headers.remotePort + ':' + super(options);
+    }
+}
+
+var agent = new customAgent({
+    maxSockets: 100,
+    keepAlive: true,
+    keepAliveMsecs: 1000,
+    maxFreeSockets: 10,
+    timeout: 60000
 });
 
 var proxy = httpProxy.createProxy({ target: 'http://whatever.com', agent: agent });
@@ -17,10 +22,12 @@ var proxy = httpProxy.createProxy({ target: 'http://whatever.com', agent: agent 
 // So that we handle the NLTM authentication response
 //
 proxy.on('proxyRes', function (proxyRes) {
-  var key = 'www-authenticate';
-  proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
+    var key = 'www-authenticate';
+    proxyRes.headers[key] = proxyRes.headers[key] && proxyRes.headers[key].split(',');
 });
 
 require('http').createServer(function (req, res) {
-  proxy.web(req, res);
+    req.headers = req.headers || {};
+    req.headers.remotePort = req.socket.remotePort;
+    proxy.web(req, res);
 }).listen(3000);


### PR DESCRIPTION
Earlier example was working well when the requests were hitting the proxy in sequential manner. But in case of multiple parallel authentication requests it fails intermittently.
Default “getName” function of NodeJS Agent class considers the hostname and port number of backend server to decide whether to reuse an existing connection or create a new connection. As all the request go to one server only one single connection (In case of load connection never expires) is created for all the requests from proxy to server. This causes an issue in NTLM authentication, as NTLM is a challenge/response authentication, one client may be sending its first request ( to which server will respond with challenge) and at same time other might send response to the challenge, as single connection is used to send all the data to server, server rejects both the request and client gets unauthorised response.
Considering from which client the request is coming and creating a different connection based on the client solves this problem.