### PR TITLE
fix(outgoing-opts): preference for values in ssl

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -36,7 +36,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
 
   ['host', 'hostname', 'socketPath', 'pfx', 'key',
     'passphrase', 'cert', 'ca', 'ciphers', 'secureProtocol'].forEach(
-    function(e) { outgoing[e] = options[forward || 'target'][e]; }
+    function(e) { outgoing[e] = outgoing[e] || options[forward || 'target'][e]; }
   );
 
   outgoing.method = options.method || req.method;


### PR DESCRIPTION
Preventing overwriting by undefined first-layer key from the main options
Resolves #1503 