### PR TITLE
setRedirectHostRewrite options.target support URL Object

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -51,7 +51,7 @@ module.exports = { // <--
     if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
-      var target = url.parse(options.target);
+      var target = typeof options.target === 'string' ? url.parse(options.target) : options.target;
       var u = url.parse(proxyRes.headers['location']);
 
       // make sure the redirected host matches the target host before rewriting


### PR DESCRIPTION
in https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/index.js#L64-L65 `options.target` can use `URL` instance: 
```js
const url = new URL(req.url);
proxyServer.web(req, res, {
    target: url
});
```
https://github.com/http-party/node-http-proxy/blob/master/lib/http-proxy/passes/web-outgoing.js#L54 don't support URL instance
