### PR TITLE
Add follow-redirects options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,20 +378,19 @@ proxyServer.listen(8015);
 *  **followRedirects**: specify whether you want to follow redirects. Possible values:
    * `false` (default): do not follow redirects
    * `true`: use follow redirects with default options
-   * Object: use follow redirects with per-request options.
-     https://github.com/follow-redirects/follow-redirects#per-request-options
+   * Object: use follow redirects with [per-request options](https://github.com/follow-redirects/follow-redirects#per-request-options).
      For example:
      ```
      followRedirects: {
        maxRedirects: 10,
-       maxBodyLength: 20 * 1024 * 1024,
+       maxBodyLength: 100000000,
        agents: { http: new http.Agent(), https: new https.Agent() },
        beforeRedirect: function (options) {
          // You can modify options here.
        },
        trackRedirects: true
      }
-     ``` Default: false - specify whether you want to follow redirects
+     ```
 *  **selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event
 *  **buffer**: stream of data to send as the request body.  Maybe you have some middleware that consumes the request stream before proxying it on e.g.  If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,23 @@ proxyServer.listen(8015);
 *  **headers**: object with extra headers to be added to target requests.
 *  **proxyTimeout**: timeout (in millis) for outgoing proxy requests
 *  **timeout**: timeout (in millis) for incoming requests
-*  **followRedirects**: true/false, Default: false - specify whether you want to follow redirects
+*  **followRedirects**: specify whether you want to follow redirects. Possible values:
+   * `false` (default): do not follow redirects
+   * `true`: use follow redirects with default options
+   * Object: use follow redirects with per-request options.
+     https://github.com/follow-redirects/follow-redirects#per-request-options
+     For example:
+     ```
+     followRedirects: {
+       maxRedirects: 10,
+       maxBodyLength: 20 * 1024 * 1024,
+       agents: { http: new http.Agent(), https: new https.Agent() },
+       beforeRedirect: function (options) {
+         // You can modify options here.
+       },
+       trackRedirects: true
+     }
+     ``` Default: false - specify whether you want to follow redirects
 *  **selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event
 *  **buffer**: stream of data to send as the request body.  Maybe you have some middleware that consumes the request stream before proxying it on e.g.  If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:
 

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -49,7 +49,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (options.auth) {
     outgoing.auth = options.auth;
   }
-  
+
   if (options.ca) {
       outgoing.ca = options.ca;
   }
@@ -73,6 +73,17 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
        ) { outgoing.headers.connection = 'close'; }
   }
 
+  //
+  // Set up options for followRedirects library.
+  // https://github.com/follow-redirects/follow-redirects#per-request-options
+  //
+  if (options.followRedirects && typeof(options.followRedirects) === "object") {
+    outgoing.maxRedirects = options.followRedirects.maxRedirects;
+    outgoing.maxBodyLength = options.followRedirects.maxBodyLength;
+    outgoing.agents = options.followRedirects.agents;
+    outgoing.beforeRedirect = options.followRedirects.beforeRedirect;
+    outgoing.trackRedirects = options.followRedirects.trackRedirects;
+  }
 
   // the final path is target path + relative path requested by user:
   var target = options[forward || 'target'];

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -367,6 +367,44 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.path).to.be('');
     });
 
+    describe("when using followRedirects", function () {
+      it ('should pass all options', function () {
+        var outgoing = {};
+        common.setupOutgoing(outgoing,
+        {
+          agent     : '?',
+          target: {
+            host      : 'how',
+            hostname  : 'are',
+            socketPath: 'you',
+            protocol: 'https:'
+          },
+          followRedirects: {
+            maxRedirects: 5,
+            maxBodyLength: 10000000,
+            agents: { http: 'http', https: 'https' },
+            beforeRedirect: function (options, headers) {
+              options.agent = '??';
+            },
+            trackRedirects: true,
+          }
+        },
+        {
+          method    : 'i',
+          url      : 'am'
+        });
+
+        expect(outgoing.maxRedirects).to.eql(5);
+        expect(outgoing.maxBodyLength).to.eql(10000000);
+        expect(outgoing.agents.http).to.eql('http');
+        expect(outgoing.agents.https).to.eql('https');
+        var options = { agent: '?' };
+        var headers = {};
+        outgoing.beforeRedirect(options, headers);
+        expect(options.agent).to.eql('??');
+        expect(outgoing.trackRedirects).to.eql(true);
+      });
+    });
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
I saw issue #1412 and PR #1441.
I'd like to support all follow-redirects options, I created another PR to support it.

I respect the attribute format of #1441.

Notes: 
- I found it's required to update DefinitelyTyped. Because `followRedirects` option is declared as boolean.
- I haven't checked which follow-redirects versions support these options. I tested 1.9.0 (defined in package-lock.json) and 1.14.1. Please check your follow-redirects version.