### PR TITLE
add parameters(proxyReq, req)

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -144,8 +144,8 @@ module.exports = {
 
       proxySocket.pipe(socket).pipe(proxySocket);
 
-      server.emit('open', proxySocket);
-      server.emit('proxySocket', proxySocket);  //DEPRECATED.
+      server.emit('open', proxySocket, proxyReq, req);
+      server.emit('proxySocket', proxySocket, proxyReq, req);  //DEPRECATED.
     });
 
     return proxyReq.end(); // XXX: CHECK IF THIS IS THIS CORRECT


### PR DESCRIPTION
the current socket cannot match the request, unable to determine which request the socket belongs to(in multiple ws proxy scenarios).