### PR TITLE
Allow forwarding a request to multiple endpoints.

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -31,12 +31,12 @@ common.isSSL = isSSL;
  */
 
 common.setupOutgoing = function(outgoing, options, req, forward) {
-  outgoing.port = options[forward || 'target'].port ||
-                  (isSSL.test(options[forward || 'target'].protocol) ? 443 : 80);
+  outgoing.port = (forward || options.target).port ||
+                  (isSSL.test((forward || options.target).protocol) ? 443 : 80);
 
   ['host', 'hostname', 'socketPath', 'pfx', 'key',
     'passphrase', 'cert', 'ca', 'ciphers', 'secureProtocol'].forEach(
-    function(e) { outgoing[e] = options[forward || 'target'][e]; }
+    function(e) { outgoing[e] = (forward || options.target)[e]; }
   );
 
   outgoing.method = options.method || req.method;
@@ -54,7 +54,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
       outgoing.ca = options.ca;
   }
 
-  if (isSSL.test(options[forward || 'target'].protocol)) {
+  if (isSSL.test((forward || options.target).protocol)) {
     outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;
   }
 
@@ -75,7 +75,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
 
 
   // the final path is target path + relative path requested by user:
-  var target = options[forward || 'target'];
+  var target = (forward || options.target);
   var targetPath = target && options.prependPath !== false
     ? (target.path || '')
     : '';
@@ -98,7 +98,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
 
   if (options.changeOrigin) {
     outgoing.headers.host =
-      required(outgoing.port, options[forward || 'target'].protocol) && !hasPort(outgoing.host)
+      required(outgoing.port, (forward || options.target).protocol) && !hasPort(outgoing.host)
         ? outgoing.host + ':' + outgoing.port
         : outgoing.host;
   }

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -63,6 +63,9 @@ function createRightProxy(type) {
       ['target', 'forward'].forEach(function(e) {
         if (typeof requestOptions[e] === 'string')
           requestOptions[e] = parse_url(requestOptions[e]);
+        else if (Array.isArray(requestOptions[e]))
+          for (var i = 0; i < requestOptions[e].length; i++)
+            requestOptions[e][i] = parse_url(requestOptions[e][i]);
       });
 
       if (!requestOptions.target && !requestOptions.forward) {

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -122,7 +122,10 @@ module.exports = {
 
         (options.buffer || req).pipe(forwardReq);
       }
-      if(!options.target) { return res.end(); }
+      if(!options.target) {
+        res.statusCode = 202;
+        return res.end(http.STATUS_CODES[res.statusCode]);
+      }
     }
 
     // Request initalization

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -107,18 +107,21 @@ module.exports = {
     var https = agents.https;
 
     if(options.forward) {
-      // If forward enable, so just pipe the request
-      var forwardReq = (options.forward.protocol === 'https:' ? https : http).request(
-        common.setupOutgoing(options.ssl || {}, options, req, 'forward')
-      );
+      var forwards = Array.isArray(options.forward) ? options.forward : [options.forward];
+      for (var forward of forwards) {
+        // If forward enable, so just pipe the request
+        var forwardReq = (forward.protocol === 'https:' ? https : http).request(
+          common.setupOutgoing(options.ssl || {}, options, req, forward)
+        );
 
-      // error handler (e.g. ECONNRESET, ECONNREFUSED)
-      // Handle errors on incoming request as well as it makes sense to
-      var forwardError = createErrorHandler(forwardReq, options.forward);
-      req.on('error', forwardError);
-      forwardReq.on('error', forwardError);
+        // error handler (e.g. ECONNRESET, ECONNREFUSED)
+        // Handle errors on incoming request as well as it makes sense to
+        var forwardError = createErrorHandler(forwardReq, forward);
+        req.on('error', forwardError);
+        forwardReq.on('error', forwardError);
 
-      (options.buffer || req).pipe(forwardReq);
+        (options.buffer || req).pipe(forwardReq);
+      }
       if(!options.target) { return res.end(); }
     }
 


### PR DESCRIPTION
Allows forwarding to multiple endpoints by setting the `forward` option to an array of path strings.

Also responds with 202 Accepted when forwarding without a target (in a separate commit in case it's not wanted).