### PR TITLE
header could be empty string

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -88,14 +88,17 @@ module.exports = { // <--
         preserveHeaderKeyCase = options.preserveHeaderKeyCase,
         rawHeaderKeyMap,
         setHeader = function(key, header) {
-          if (header == undefined) return;
-          if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
-            header = common.rewriteCookieProperty(header, rewriteCookieDomainConfig, 'domain');
+          if (header) {
+              if (rewriteCookieDomainConfig && key.toLowerCase() === 'set-cookie') {
+                header = common.rewriteCookieProperty(header, rewriteCookieDomainConfig, 'domain');
+              }
+              if (rewriteCookiePathConfig && key.toLowerCase() === 'set-cookie') {
+                header = common.rewriteCookieProperty(header, rewriteCookiePathConfig, 'path');
+              }
+              res.setHeader(String(key).trim(), header);
+          } else {
+              return;
           }
-          if (rewriteCookiePathConfig && key.toLowerCase() === 'set-cookie') {
-            header = common.rewriteCookieProperty(header, rewriteCookiePathConfig, 'path');
-          }
-          res.setHeader(String(key).trim(), header);
         };
 
     if (typeof rewriteCookieDomainConfig === 'string') { //also test for ''


### PR DESCRIPTION
changing condition, do setHeader only when header is not 

null
undefined
NaN
empty string ("")
0
false

It preserve from exception:

[HPM] GET /events?uuids=18cd56cb-45cb-43e6-a397-c4531cc57866 -> http://localhost:8099
_http_outgoing.js:545
    throw new ERR_INVALID_HTTP_TOKEN('Header name', name);
    ^

TypeError [ERR_INVALID_HTTP_TOKEN]: Header name must be a valid HTTP token [""]
    at ServerResponse.setHeader (_http_outgoing.js:563:3)
