### PR TITLE
Fix websocket socket close before response

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -111,7 +111,7 @@ module.exports = {
     proxyReq.on('error', onOutgoingError);
     proxyReq.on('response', function (res) {
       // if upgrade event isn't going to happen, close the socket
-      if (!res.upgrade) {
+      if (!res.upgrade && socket.readyState !== "closed") {
         socket.write(createHttpHeader('HTTP/' + res.httpVersion + ' ' + res.statusCode + ' ' + res.statusMessage, res.headers));
         res.pipe(socket);
       }


### PR DESCRIPTION
There are situations where the socket can already be closed. Writing to
it will result in a "This socket has been ended by the other party"
error which results in the node service to terminate (cannot be catched
by a try-catch block).