### PR TITLE
Fix 'aborted' detection on Node v15.5.0+

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -18,6 +18,11 @@ var nativeAgents = { http: httpNative, https: httpsNative };
  * flexible.
  */
 
+// 'aborted' event stopped working reliably on v15.5.0 and was later removed entirely
+var supportsAbortedEvent = (function () {
+  var ver = process.versions.node.split('.').map(Number);
+  return ver[0] <= 14 || ver[0] === 15 && ver[1] <= 4;
+}());
 
 module.exports = {
 
@@ -143,9 +148,18 @@ module.exports = {
     }
 
     // Ensure we abort proxy if request is aborted
-    req.on('aborted', function () {
-      proxyReq.abort();
-    });
+    if (supportsAbortedEvent) {
+      req.on('aborted', function () {
+        proxyReq.abort();
+      });
+    } else {
+      res.on('close', function () {
+        var aborted = !res.writableFinished;
+        if (aborted) {
+          proxyReq.abort();
+        }
+      });
+    }
 
     // handle errors in proxy and incoming request, just like for forward proxy
     var proxyError = createErrorHandler(proxyReq, options.target);


### PR DESCRIPTION
This fixes a major memory leak I encountered usign this on Node v16.
Doing a binary search of node versions, the problem appears to originate in v15.5.0 as a result of nodejs/node#33035, however later changes have quietly completely removed the 'aborted' event that `http-proxy` relies on, and later added a deprecation note about it (which seems to actually be incorrect).
Despite what the notes about [DEP0156](https://nodejs.org/dist/latest-v16.x/docs/api/deprecations.html#DEP0156) say, the only way I could get this module working reliably again was to replace `req.on('aborted')` with instead checking `res.on('close')` and looking at `res.writeableFinished`.

For a very easy test, load any video file over the proxy, and seek backwards in Chrome.  For example, run the following:
```javascript
const httpProxy = require('http-proxy');

httpProxy.createProxyServer({
  target: 'http://files.dashingstrike.com.s3.amazonaws.com',
  changeOrigin: true,
}).listen(8080);
```

And then open http://localhost:8080/SplodyGameplayLong.mp4, and then seek backwards in the file.  Chrome will abort hundreds of requests (each of which is requesting ~32MB), which, if not properly aborted, will leak connections as well as hundreds of MBs of TCP kernel memory per second (quickly bricking your instance, making it unreachable even by SSH, as I found out -_-).  On Linux, you can view TCP kernel memory used with `cat /proc/net/sockstat` (`mem` is count of 4K pages), or `ss -atn state big` if you have `ss` installed.