### PR TITLE
Add lookup option to override dns lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,22 @@ proxyServer.listen(8015);
 
     };
     ```
+*  **lookup**: define a custom dns [lookup](https://nodejs.org/docs/latest-v12.x/api/dns.html#dns_dns_lookup_hostname_options_callback) function to use when resolving target/forward hostnames. 
+
+   Example: add dns caching
+
+   ```js
+    const dlc = require('dns-lookup-cache');
+
+    module.exports = (req, res, next) => {
+
+      proxy.web(req, res, {
+        target: 'http://example.com',
+        lookup: dlc.lookup,
+      }, next);
+
+    };
+  ```
 
 **NOTE:**
 `options.ws` and `options.ssl` are optional.

--- a/examples/http/custom-lookup.js
+++ b/examples/http/custom-lookup.js
@@ -1,0 +1,23 @@
+var colors = require('colors'),
+    httpProxy = require('../../lib/http-proxy')
+    dns = require('dns');
+
+
+httpProxy.createServer({
+    target: 'http://example.com:80',
+    changeOrigin: true,
+
+    // Define custom dns lookup function
+    lookup: function (host, options, callback) {
+        console.log('Looking up', host);
+
+        dns.lookup(host, options, function (err, address, family) {
+            console.log('Result: err:', err, ', address:', address, 'family:', family);
+            
+            callback(err, address, family);
+        });
+    },        
+}).listen(8003);
+
+
+console.log('http proxy server'.blue + ' started '.green.bold + 'on port '.blue + '8003'.yellow);

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -58,6 +58,9 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
     outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;
   }
 
+  if (options.lookup) {
+    outgoing.lookup = options.lookup
+  }
 
   outgoing.agent = options.agent || false;
   outgoing.localAddress = options.localAddress;

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -367,6 +367,17 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.path).to.be('');
     });
 
+    it('should pass through lookup', function() {
+      var outgoing = {};
+      function lookup(hostname, options, callback) {
+        callback('This is just a test');
+      }
+      common.setupOutgoing(outgoing, {
+        target: 'http://example.com',
+        lookup: lookup,
+      }, { url: '' });
+      expect(outgoing.lookup).to.be(lookup);
+    });
   });
 
   describe('#setupSocket', function () {


### PR DESCRIPTION
The cause of this is that when proxying api requests to a hostname, node will perform a dns query for every single request, which adds unnecessary overhead. While I was investigating I found https://github.com/nodejs/node/issues/5893 and understood that there is no built in dns caching in node and that it seemingly bypasses OS dns cache. Adding a dns cache into `http-proxy` would clearly not be optimal, but by exposing the `lookup` option for `request()` we can customize the dns lookup that `http-proxy` performs and add our own cache, or inject https://www.npmjs.com/package/dns-lookup-cache or something similiar. (fixes http-party/node-http-proxy#653)

This configuration would also allow to customize the DNS lookup (fixes http-party/node-http-proxy#1315)

One problem with this is that the [`request()` `lookup` option](https://nodejs.org/docs/latest-v12.x/api/http.html#http_http_request_url_options_callback) is only available in node v12 and later, so using the option when running node 8/10 would not have any effect. shouldn't implode either, but does nothing.