### PR TITLE
fix request abort for node 16+

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -143,8 +143,8 @@ module.exports = {
     }
 
     // Ensure we abort proxy if request is aborted
-    req.on('aborted', function () {
-      proxyReq.abort();
+    res.on('close', function () {
+      proxyReq.destroy();
     });
 
     // handle errors in proxy and incoming request, just like for forward proxy


### PR DESCRIPTION
After upgrading to node 16, the web proxy stopped working when requests were aborted. The specific use case was SSE where the incoming request has ended but the server response is a long lived http connection. The 'aborted' event and the 'abort' method are deprecated. The response 'close' event and the 'destroy' method are the correct alternatives and pre-date node 8, which is the minimum version this package currently supports. I did run tests on node 8/10/12/14/16 and they failed on node 16 prior to this fix and all pass after this fix.