### PR TITLE
crash when 'options.target' is an object instead a string

### DIFF
--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -51,7 +51,8 @@ module.exports = { // <--
     if ((options.hostRewrite || options.autoRewrite || options.protocolRewrite)
         && proxyRes.headers['location']
         && redirectRegex.test(proxyRes.statusCode)) {
-      var target = url.parse(options.target);
+      const targetStr = typeof options.target === 'string' ? options.target : options.target.href;
+      var target = url.parse(targetStr);
       var u = url.parse(proxyRes.headers['location']);
 
       // make sure the redirected host matches the target host before rewriting


### PR DESCRIPTION
Sometimes the attribute 'options.target' is not a string and is an object like:
```json
{
    "protocol": "http:",
    "slashes": true,
    "auth": null,
    "host": "some.hostname.fake",
    "port": null,
    "hostname": "some.hostname.fake",
    "hash": null,
    "search": null,
    "query": null,
    "pathname": "/",
    "path": "/",
    "href": "http://some.hostname.fake"
}
```
In this case is necessary to access to the attribute 'options.target.href'.