### PR TITLE
Update outdated LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
   node-http-proxy
 
-  Copyright (c) 2010-2016 Charlie Robbins, Jarrett Cruger & the Contributors.
+  Copyright (c) 2010-present Charlie Robbins, Jarrett Cruger & the Contributors.
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the


### PR DESCRIPTION
Updated the outdated copyright year to the present.  So there will not be a need for any further license year updates