### PR TITLE
Fixed type error when req.socket is undefined

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -154,7 +154,7 @@ module.exports = {
 
     function createErrorHandler(proxyReq, url) {
       return function proxyError(err) {
-        if (req.socket.destroyed && err.code === 'ECONNRESET') {
+        if (req.socket?.destroyed && err.code === 'ECONNRESET') {
           server.emit('econnreset', err, req, res, url);
           return proxyReq.abort();
         }


### PR DESCRIPTION
When req.socket is undefined a type error occured, this error is fixed within this pull request. Fixed error - uncaughtException: TypeError: Cannot read properties of undefined (reading 'destroyed')