### PR TITLE
Respect `NODE_TLS_REJECT_UNAUTHORIZED` environment variable

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -55,7 +55,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   }
 
   if (isSSL.test(options[forward || 'target'].protocol)) {
-    outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? true : options.secure;
+    // Respect `NODE_TLS_REJECT_UNAUTHORIZED` environment variable (https://nodejs.org/docs/latest/api/cli.html#node_tls_reject_unauthorizedvalue)
+    var NODE_TLS_REJECT_UNAUTHORIZED = process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
+    var rejectUnauthorizedEnv = typeof NODE_TLS_REJECT_UNAUTHORIZED !== 'undefined' ? NODE_TLS_REJECT_UNAUTHORIZED.toString() : undefined;
+    outgoing.rejectUnauthorized = (typeof options.secure === "undefined") ? (rejectUnauthorizedEnv !== '0') : options.secure;
   }
 
 


### PR DESCRIPTION
https://github.com/vercel/next.js/discussions/49546#discussioncomment-5852688
https://github.com/vercel/next.js/issues/45743

`NODE_TLS_REJECT_UNAUTHORIZED` does not work when proxy to https target. Because the `rejectUnauthorized` parameter was specified.

So I use the `NODE_TLS_REJECT_UNAUTHORIZED` as the `rejectUnauthorized`'s value when `secure` wasn't specified.

This is my test code

```javascript
/* test.js */
process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0
const httpProxy = require('./lib/http-proxy')

const proxy = httpProxy.createServer({
  target: '<Some unsafe https url>',
  changeOrigin: true,
  ignorePath: false,
  xfwd: true,
  ws: true,
  followRedirects: false,
})
proxy.on('error', e => {
  console.log('Proxy error:', e)
})
proxy.on('proxyRes', (proxyRes, req, res) => {
  console.log('RAW Response from the target', JSON.stringify(proxyRes.headers, true, 2));
})
proxy.listen(8003)
```

Before:
```bash
$ node test.js
(node:9292) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
Proxy error: Error: unable to get local issuer certificate
    at TLSSocket.onConnectSecure (node:_tls_wrap:1540:34)
    at TLSSocket.emit (node:events:513:28)
    at TLSSocket._finishInit (node:_tls_wrap:959:8)
    at ssl.onhandshakedone (node:_tls_wrap:743:12) {
  code: 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY'
}
```

After:
```bash
$ node test
(node:17712) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
RAW Response from the target {
  "date": "Wed, 17 May 2023 05:04:50 GMT",
  "content-type": "application/json;charset=UTF-8",
  "content-length": "158",
  "connection": "close",
  "x-content-type-options": "nosniff",
  "x-xss-protection": "1; mode=block",
  "cache-control": "no-cache, no-store, max-age=0, must-revalidate",
  "pragma": "no-cache",
  "expires": "0",
  "strict-transport-security": "max-age=15724800; includeSubDomains",
  "x-frame-options": "DENY"
}
```