### PR TITLE
Use `Object.assign` instead of deprecated `util._extend`

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,6 +1,5 @@
 var common   = exports,
     url      = require('url'),
-    extend   = require('util')._extend,
     required = require('requires-port');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
@@ -40,10 +39,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   );
 
   outgoing.method = options.method || req.method;
-  outgoing.headers = extend({}, req.headers);
+  outgoing.headers = Object.assign({}, req.headers);
 
   if (options.headers){
-    extend(outgoing.headers, options.headers);
+    Object.assign(outgoing.headers, options.headers);
   }
 
   if (options.auth) {

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -1,5 +1,4 @@
 var httpProxy = module.exports,
-    extend    = require('util')._extend,
     parse_url = require('url').parse,
     EE3       = require('eventemitter3'),
     http      = require('http'),
@@ -47,9 +46,9 @@ function createRightProxy(type) {
         args[cntr] !== res
       ) {
         //Copy global options
-        requestOptions = extend({}, options);
+        requestOptions = Object.assign({}, options);
         //Overwrite with request options
-        extend(requestOptions, args[cntr]);
+        Object.assign(requestOptions, args[cntr]);
 
         cntr--;
       }


### PR DESCRIPTION
When building an app using Vite, there is this deprecationw arning when using Node.js 22:
```
[DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
```

This PR resolves that.

`Object.assign` is [supported since Node.js 4](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign).