### PR TITLE
fix: Avoid using deprecated util._extend()

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,6 +1,6 @@
 var common   = exports,
     url      = require('url'),
-    extend   = require('util')._extend,
+    extend   = Object.assign, // Avoids deprecation warning in Node22 for: require('util')._extend,
     required = require('requires-port');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -1,5 +1,5 @@
 var httpProxy = module.exports,
-    extend    = require('util')._extend,
+    extend    = Object.assign, // Avoids deprecation warning in Node22 for: require('util')._extend,
     parse_url = require('url').parse,
     EE3       = require('eventemitter3'),
     http      = require('http'),


### PR DESCRIPTION
Node 22 dumps a deprecation warning when using `util._extend()`:

```
[DEP0060] DeprecationWarning: The `util._extend` API is deprecated. 
Please use Object.assign() instead.
```