### PR TITLE
forward exceptions on parsing incomping requests to the 'error' event…

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -78,8 +78,13 @@ function createRightProxy(type) {
          * refer to the connection socket
          * pass(req, socket, options, head)
          */
-        if(passes[i](req, res, requestOptions, head, this, cbl)) { // passes can return a truthy value to halt the loop
-          break;
+        try {
+          if(passes[i](req, res, requestOptions, head, this, cbl)) { // passes can return a truthy value to halt the loop
+            break;
+          }
+        } catch ( e ) {
+          this.emit('error', e);
+          continue;
         }
       }
     };


### PR DESCRIPTION
… to be handled by applications (fixed ERR_INVALID_HTTP_TOKEN)

I've posted the related issue here https://github.com/http-party/node-http-proxy/issues/1679

Please review the fix. Thank you!