### PR TITLE
Using NodeJS v22.11.0 DeprecationWarning util._extend API fixed

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,6 +1,6 @@
 var common   = exports,
     url      = require('url'),
-    extend   = require('util')._extend,
+    extend   = Object.assign,
     required = require('requires-port');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -1,5 +1,5 @@
 var httpProxy = module.exports,
-    extend    = require('util')._extend,
+    extend    = Object.assign,
     parse_url = require('url').parse,
     EE3       = require('eventemitter3'),
     http      = require('http'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-proxy",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/http-party/node-http-proxy.git"


### PR DESCRIPTION
`util._extend` API is replaced by `Object.assign`