### PR TITLE
fix: replace deprecated util._extend with Object.assign()

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -47,7 +47,7 @@ function createRightProxy(type) {
         args[cntr] !== res
       ) {
         //Copy global options
-        requestOptions = extend({}, options);
+        requestOptions = Object.assign({}, options);
         //Overwrite with request options
         extend(requestOptions, args[cntr]);
 


### PR DESCRIPTION
The functionality remains identical as both methods perform shallow copies of object properties. `Object.assign()` is the standard modern approach for this operation.

Resolves this warning:
```
[DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
```