### PR TITLE
support function type for options.localAddress

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -60,7 +60,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
 
 
   outgoing.agent = options.agent || false;
-  outgoing.localAddress = options.localAddress;
+  outgoing.localAddress = typeof options.localAddress === 'function' ? options.localAddress() : options.localAddress;
 
   //
   // Remark: If we are false and not upgrading, set the connection: close. This is the right thing to do


### PR DESCRIPTION
In some cases, the machine has multiple egress IPs, and we want to customize dynamic egress IP rules. A dynamic localAddress specification method is necessary, so I think supporting localAddress as a function input is a good choice.