### PR TITLE
Fix README bug in selfHandleResponse example

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,8 +510,8 @@ data.
             console.log("res from proxied server:", body);
             res.end("my response to cli");
         });
+        proxy.web(req, res, option);
     });
-    proxy.web(req, res, option);
 
 
 ```


### PR DESCRIPTION
I was implementing my response handler and observed strange behavior when running the README example. The `proxy.web(req, res, option);` line should be inside the proxyRes handler function (the current example does not send a response to the client).