### PR TITLE
Update common.js

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -1,6 +1,6 @@
 var common   = exports,
     url      = require('url'),
-    extend   = require('util')._extend,
+    ObjectAssign = Object.assign,
     required = require('requires-port');
 
 var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
@@ -40,10 +40,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   );
 
   outgoing.method = options.method || req.method;
-  outgoing.headers = extend({}, req.headers);
+  outgoing.headers = ObjectAssign({}, req.headers);
 
   if (options.headers){
-    extend(outgoing.headers, options.headers);
+    ObjectAssign(outgoing.headers, options.headers);
   }
 
   if (options.auth) {


### PR DESCRIPTION
Updated deprecated util._extend to Object.assign

I have an implementation that uses http-proxy-middleware that was failing because of this, so I copied my fix from there.
Hope this is helpful