### PR TITLE
fixes #1706

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -47,6 +47,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   }
 
   if (options.auth) {
+    delete outgoing.headers.authorization;
     outgoing.auth = options.auth;
   }
   

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -453,6 +453,40 @@ describe('#createProxyServer.web() using own http server', function () {
     http.request('http://127.0.0.1:8081', function() {}).end();
   });
 
+  describe("with an authorization header from client", function () {
+    const headers = {
+      'authorization': "Bearer " + new Buffer("mock-jwt-token").toString('base64'),
+    };
+
+    it.only("should proxy the request with the Authorization header set", function (done) {
+      var proxy = httpProxy.createProxyServer({
+        target: "http://127.0.0.1:8080",
+        auth: "user:pass",
+      });
+
+      function requestHandler(req, res) {
+        proxy.web(req, res);
+      }
+
+      var proxyServer = http.createServer(requestHandler);
+
+      var source = http.createServer(function (req, res) {
+        source.close();
+        proxyServer.close();
+        var auth = new Buffer(req.headers.authorization.split(' ')[1], 'base64');
+        expect(req.method).to.eql("GET");
+        expect(auth.toString()).to.eql("user:pass");
+        done();
+      });
+
+      proxyServer.listen("8081");
+      source.listen("8080");
+
+      http.request("http://127.0.0.1:8081", { headers }, function () {}).end();
+    });
+  });
+
+
   it('should proxy requests to multiple servers with different options', function (done) {
     var proxy = httpProxy.createProxyServer();
 


### PR DESCRIPTION
When the client sends authorization header and the configuration options have `auth`, the authorization header is not sent to the upstream. This way the http-proxy will behave based on the configuration provided, not the data sent from client